### PR TITLE
feat: print GitHub rate-limit footer after scan and issues

### DIFF
--- a/lib/gem_contribute/cli.rb
+++ b/lib/gem_contribute/cli.rb
@@ -11,6 +11,7 @@ module GemContribute
     autoload :ForkCloneBranch, "gem_contribute/cli/fork_clone_branch"
     autoload :Git, "gem_contribute/cli/fork_clone_branch"
     autoload :Submit, "gem_contribute/cli/submit"
+    autoload :RateLimitFooter, "gem_contribute/cli/rate_limit_footer"
     USAGE = <<~USAGE
       Usage: gem-contribute <command> [options]
 

--- a/lib/gem_contribute/cli/issues.rb
+++ b/lib/gem_contribute/cli/issues.rb
@@ -27,14 +27,18 @@ module GemContribute
         target = argv.shift
         return print_usage if target.nil?
 
-        if target == "all"
-          run_all
-        else
-          project = resolve_or_fail(target)
-          return 1 if project.nil?
-
-          list_issues(project)
-        end
+        status = if target == "all"
+                   run_all
+                 else
+                   project = resolve_or_fail(target)
+                   if project.nil?
+                     1
+                   else
+                     list_issues(project)
+                   end
+                 end
+        RateLimitFooter.print(adapter: @adapter, stdout: @stdout)
+        status
       rescue AdapterError => e
         @stderr.puts "gem-contribute: #{e.message}"
         1

--- a/lib/gem_contribute/cli/rate_limit_footer.rb
+++ b/lib/gem_contribute/cli/rate_limit_footer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GemContribute
+  module CLI
+    # Prints a one-line GitHub rate-limit footer after `scan` or `issues`
+    # finishes its main output, when the adapter has rate-limit data.
+    #
+    # Format: "GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC"
+    #
+    # When `adapter.rate_limit` is nil (e.g. every call was served from cache),
+    # nothing is printed — see #4 acceptance criteria.
+    module RateLimitFooter
+      module_function
+
+      # @param adapter [GemContribute::HostAdapters::GitHubAdapter]
+      # @param stdout [IO]
+      def print(adapter:, stdout: $stdout)
+        rate_limit = adapter.respond_to?(:rate_limit) ? adapter.rate_limit : nil
+        return if rate_limit.nil?
+
+        remaining = format_with_separators(rate_limit.remaining)
+        limit = format_with_separators(rate_limit.limit)
+        reset = rate_limit.reset_at.utc.strftime("%H:%M")
+        stdout.puts "GitHub rate limit: #{remaining} / #{limit} remaining · resets at #{reset} UTC"
+      end
+
+      def format_with_separators(integer)
+        integer.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+      end
+    end
+  end
+end

--- a/lib/gem_contribute/cli/scan.rb
+++ b/lib/gem_contribute/cli/scan.rb
@@ -40,6 +40,7 @@ module GemContribute
         # self-injection is intentionally additive, not part of the count.
         print_summary(tally_hosts(projects), gems.size)
         scan_github_projects(projects)
+        RateLimitFooter.print(adapter: @adapter, stdout: @stdout)
         0
       rescue LockfileNotFound => e
         @stderr.puts "gem-contribute: #{e.message}"

--- a/spec/gem_contribute/cli/issues_spec.rb
+++ b/spec/gem_contribute/cli/issues_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe GemContribute::CLI::Issues do
   end
 
   before { allow(resolver).to receive(:resolve).and_return(project) }
+  # Default: footer is a no-op unless a test explicitly returns a RateLimit.
+  before { allow(adapter).to receive(:rate_limit).and_return(nil) }
 
   it "exits 2 with usage when no gem name is given" do
     expect(cli.run([])).to eq(2)
@@ -132,6 +134,36 @@ RSpec.describe GemContribute::CLI::Issues do
       expect(cli.run(["all"])).to eq(0)
       expect(stderr.string).to include("warning")
       expect(stdout.string).to include("#42")
+    end
+  end
+
+  describe "rate-limit footer" do
+    it "appends the footer after `issues <gem>` when adapter recorded one" do
+      allow(adapter).to receive(:issues).and_return([issue(1, "x")])
+      allow(adapter).to receive(:rate_limit).and_return(
+        Struct.new(:limit, :remaining, :reset_at).new(5000, 4587, Time.utc(2026, 4, 30, 14, 32, 0))
+      )
+
+      expect(cli.run(["rubocop"])).to eq(0)
+      expect(stdout.string).to include("GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC")
+    end
+
+    it "appends the footer after `issues all` when adapter recorded one" do
+      allow(adapter).to receive(:issues).and_return([])
+      allow(adapter).to receive(:rate_limit).and_return(
+        Struct.new(:limit, :remaining, :reset_at).new(60, 12, Time.utc(2026, 4, 30, 9, 5, 0))
+      )
+
+      expect(cli.run(["all"])).to eq(0)
+      expect(stdout.string).to include("GitHub rate limit: 12 / 60 remaining · resets at 09:05 UTC")
+    end
+
+    it "prints nothing extra when the adapter has no rate-limit data" do
+      allow(adapter).to receive(:issues).and_return([])
+      # rate_limit defaults to nil via the spec's top-level before block.
+
+      expect(cli.run(["all"])).to eq(0)
+      expect(stdout.string).not_to include("GitHub rate limit")
     end
   end
 end

--- a/spec/gem_contribute/cli/rate_limit_footer_spec.rb
+++ b/spec/gem_contribute/cli/rate_limit_footer_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "time"
+
+RSpec.describe GemContribute::CLI::RateLimitFooter do
+  let(:stdout) { StringIO.new }
+  let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
+
+  def rate_limit(remaining:, limit:, reset_at:)
+    Struct.new(:limit, :remaining, :reset_at).new(limit, remaining, reset_at)
+  end
+
+  it "prints a one-line footer when adapter has rate-limit data" do
+    allow(adapter).to receive(:rate_limit).and_return(
+      rate_limit(remaining: 4587, limit: 5000, reset_at: Time.utc(2026, 4, 30, 14, 32, 0))
+    )
+
+    described_class.print(adapter: adapter, stdout: stdout)
+
+    expect(stdout.string).to eq(
+      "GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC\n"
+    )
+  end
+
+  it "uses thousand-separators for both remaining and limit" do
+    allow(adapter).to receive(:rate_limit).and_return(
+      rate_limit(remaining: 12_345, limit: 100_000, reset_at: Time.utc(2026, 4, 30, 9, 0, 0))
+    )
+
+    described_class.print(adapter: adapter, stdout: stdout)
+
+    expect(stdout.string).to include("12,345 / 100,000 remaining")
+  end
+
+  it "prints UTC even when reset_at is in another timezone" do
+    # 14:32 UTC = 10:32 EDT; the footer must convert.
+    allow(adapter).to receive(:rate_limit).and_return(
+      rate_limit(
+        remaining: 4587, limit: 5000,
+        reset_at: Time.new(2026, 4, 30, 10, 32, 0, "-04:00")
+      )
+    )
+
+    described_class.print(adapter: adapter, stdout: stdout)
+
+    expect(stdout.string).to include("resets at 14:32 UTC")
+  end
+
+  it "prints nothing when adapter.rate_limit is nil (cache-only run)" do
+    allow(adapter).to receive(:rate_limit).and_return(nil)
+
+    described_class.print(adapter: adapter, stdout: stdout)
+
+    expect(stdout.string).to eq("")
+  end
+
+  it "prints nothing when the adapter does not expose rate_limit at all" do
+    bare_adapter = Object.new
+
+    described_class.print(adapter: bare_adapter, stdout: stdout)
+
+    expect(stdout.string).to eq("")
+  end
+end

--- a/spec/gem_contribute/cli/scan_spec.rb
+++ b/spec/gem_contribute/cli/scan_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe GemContribute::CLI::Scan do
   let(:fixtures) { File.expand_path("../../fixtures", __dir__) }
   let(:lockfile) { File.join(fixtures, "Gemfile.simple.lock") }
 
+  # Default: every adapter mock returns nil from rate_limit so the
+  # post-scan footer is a no-op. Tests that exercise the footer
+  # explicitly override this.
+  before { allow(adapter).to receive(:rate_limit).and_return(nil) }
+
   def project(gem_name, host: "github.com", owner: "ruby", repo: nil)
     GemContribute::Project.new(
       gem_name: gem_name,
@@ -91,5 +96,25 @@ RSpec.describe GemContribute::CLI::Scan do
     expect(scan.run([lockfile])).to eq(0)
     expect(stderr.string).to include("warning: sidekiq")
     expect(stderr.string).to include("boom")
+  end
+
+  it "appends the GitHub rate-limit footer when adapter recorded one" do
+    allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
+    allow(adapter).to receive(:issues).and_return([{ "number" => 1 }])
+    allow(adapter).to receive(:rate_limit).and_return(
+      Struct.new(:limit, :remaining, :reset_at).new(5000, 4587, Time.utc(2026, 4, 30, 14, 32, 0))
+    )
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stdout.string).to include("GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC")
+  end
+
+  it "omits the footer when the adapter has no rate-limit data (cache-only run)" do
+    allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
+    allow(adapter).to receive(:issues).and_return([{ "number" => 1 }])
+    # adapter.rate_limit defaults to nil via the top-level before block.
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stdout.string).not_to include("GitHub rate limit")
   end
 end


### PR DESCRIPTION
Closes #4.

Adds a one-line footer after `scan` and `issues <gem|all>` that exposes the GitHub adapter's recorded rate-limit state:

```
GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC
```

Anonymous users get 60 requests/hr against GitHub's API. A 50-gem scan can plausibly burn through the entire budget; without surfacing the state, the only signal a user gets is the next run failing - by which point they don't know whether to wait 4 minutes or 40.

## Implementation

- New module `GemContribute::CLI::RateLimitFooter` with a `print(adapter:, stdout:)` class method. Reads `adapter.rate_limit` and renders the footer; no-op when `nil` (cache-only runs that didn't make a real HTTP call) or when the adapter doesn't expose `rate_limit` at all (future non-GitHub adapters).
- `Scan#run` and `Issues#run` call the footer after their main work but before returning their exit status.
- Footer time is normalized to UTC. Numbers use thousand-separators.

The GitHub adapter already records `X-RateLimit-*` headers from each response into `@rate_limit` (see `record_rate_limit` in `lib/gem_contribute/host_adapters/github_adapter.rb`), so this PR is purely the display path.

## Tests

- `spec/.../rate_limit_footer_spec.rb` (new) - happy path, thousand-separators, UTC conversion, nil rate-limit (cache-only), bare adapter without `rate_limit` method.
- `spec/.../scan_spec.rb` and `spec/.../issues_spec.rb` - integration tests covering footer present and absent for both commands.

🤖 Authored with Claude Code