### PR TITLE
init: explicit clone_root setup; remove silent default (closes #15)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for considering a contribution. This project is *about* lowering the fric
 
 ```
 gem install gem-contribute
-gem-contribute auth login
+gem-contribute init                       # set clone_root and auth with GitHub
 gem-contribute fix gem-contribute/issue-5
 bundle install
 bin/rspec               # tests should pass on a clean checkout

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Requires Ruby 3.2 or later.
 The CLI is a small set of subcommands:
 
 ```
+gem-contribute init                   One-time interactive setup (sets clone_root, then auth).
 gem-contribute scan [path]            Summarize the contributable surface of a Gemfile.lock.
 gem-contribute issues <gem|all>       List "good first issue" issues for one gem (or all).
 gem-contribute auth login             Authenticate with GitHub via OAuth device flow.
@@ -46,29 +47,29 @@ gem-contribute config set <key> <val> Persist user preferences (e.g. clone_root)
 A typical session:
 
 ```sh
-$ gem-contribute auth login              # one-time; uses GitHub device flow
+$ gem-contribute init                    # one-time: sets clone_root, then auth via GitHub device flow
 $ gem-contribute scan                    # see what's worth contributing to
 $ gem-contribute issues rubocop          # drill into one project's issues
 $ gem-contribute fix rubocop/12345       # fork, clone, branch
-$ cd ~/code/oss/rubocop/rubocop          # (or wherever clone_root points)
+$ cd ~/code/oss/rubocop/rubocop          # whatever clone_root you set during init
 # ... make your change, commit ...
 $ gem-contribute submit                  # push + open the PR compare page in your browser
 ```
 
-The `auth login` step opens GitHub's device-flow page in your browser and copies the one-time code to your clipboard — same UX as `gh auth login`, no token paste, no client secret. Tokens cache at `~/.config/gem-contribute/auth.json` (mode 0600).
+The auth step (run automatically by `init`, or directly via `gem-contribute auth login`) opens GitHub's device-flow page in your browser and copies the one-time code to your clipboard — same UX as `gh auth login`, no token paste, no client secret. Tokens cache at `~/.config/gem-contribute/auth.json` (mode 0600).
 
 ## Configuration
 
-User config lives at `~/.config/gem-contribute/config.yml`. Manage it with `gem-contribute config`:
+User config lives at `~/.config/gem-contribute/config.yml`. The interactive way to set it is `gem-contribute init`; for scripted setup, use `gem-contribute config`:
 
 ```sh
 gem-contribute config set clone_root ~/Projects/oss
 gem-contribute config list
 ```
 
-| Key          | Default      | Notes                                            |
-|--------------|--------------|--------------------------------------------------|
-| `clone_root` | `~/code/oss` | Where `fix` clones forks (`<root>/<owner>/<repo>`). |
+| Key          | Notes                                                                              |
+|--------------|------------------------------------------------------------------------------------|
+| `clone_root` | Where `fix` clones forks (`<root>/<owner>/<repo>`). Set via `init` or `config set`. No default — `fix` errors if unset. |
 
 ## Design
 

--- a/lib/gem_contribute/cli.rb
+++ b/lib/gem_contribute/cli.rb
@@ -7,6 +7,7 @@ module GemContribute
     autoload :Scan, "gem_contribute/cli/scan"
     autoload :Auth, "gem_contribute/cli/auth"
     autoload :Config, "gem_contribute/cli/config"
+    autoload :Init, "gem_contribute/cli/init"
     autoload :Issues, "gem_contribute/cli/issues"
     autoload :ForkCloneBranch, "gem_contribute/cli/fork_clone_branch"
     autoload :Git, "gem_contribute/cli/fork_clone_branch"
@@ -16,6 +17,7 @@ module GemContribute
       Usage: gem-contribute <command> [options]
 
       Commands:
+        init                     One-time interactive setup (sets clone_root).
         scan [path]              Summarize the contributable surface of a Gemfile.lock.
                                  Path defaults to ./Gemfile.lock.
         issues <gem|all>         List open "good first issue" issues for a gem (or all gems).
@@ -59,6 +61,7 @@ module GemContribute
     end
 
     COMMANDS = {
+      "init" => ->(o, e) { Init.new(stdout: o, stderr: e) },
       "scan" => ->(o, e) { Scan.new(stdout: o, stderr: e, adapter: github_adapter) },
       "issues" => ->(o, e) { Issues.new(stdout: o, stderr: e, adapter: github_adapter) },
       "config" => ->(o, e) { Config.new(stdout: o, stderr: e) },

--- a/lib/gem_contribute/cli/config.rb
+++ b/lib/gem_contribute/cli/config.rb
@@ -18,8 +18,9 @@ module GemContribute
           list                 Print all configured values.
 
         Keys:
-          clone_root           Directory where forks are cloned (default: ~/code/oss).
-                               Example: gem-contribute config set clone_root ~/Projects/oss
+          clone_root           Directory where forks are cloned. Set with
+                               `gem-contribute init` (interactive) or
+                               `gem-contribute config set clone_root <path>`.
       USAGE
 
       def initialize(stdout: $stdout, stderr: $stderr, config: GemContribute::Config.new)
@@ -73,13 +74,14 @@ module GemContribute
           return 1
         end
 
-        @stdout.puts @config.to_h.fetch(key, "(not set — default applies)")
+        @stdout.puts @config.to_h.fetch(key, "(not set; run `gem-contribute init`)")
         0
       end
 
       def list
         @stdout.puts "Configuration (#{GemContribute::Config.default_path}):"
-        @stdout.puts "  clone_root = #{@config.clone_root}"
+        display = @config.clone_root || "(not set; run `gem-contribute init`)"
+        @stdout.puts "  clone_root = #{display}"
         0
       end
     end

--- a/lib/gem_contribute/cli/fork_clone_branch.rb
+++ b/lib/gem_contribute/cli/fork_clone_branch.rb
@@ -48,6 +48,8 @@ module GemContribute
       end
 
       def run(argv)
+        return missing_clone_root if @clone_root.nil?
+
         target = argv.shift
         return print_usage_error if target.nil? || !target.include?("/")
 
@@ -68,6 +70,11 @@ module GemContribute
       end
 
       private
+
+      def missing_clone_root
+        @stderr.puts "clone_root is not configured. Run `gem-contribute init` first."
+        1
+      end
 
       def print_usage_error
         @stderr.puts "Usage: gem-contribute fork-clone-branch <gem>/<issue#>"

--- a/lib/gem_contribute/cli/init.rb
+++ b/lib/gem_contribute/cli/init.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module GemContribute
+  module CLI
+    # `gem-contribute init` — interactive one-time setup that writes the
+    # user's `clone_root` to ~/.config/gem-contribute/config.yml.
+    #
+    # Without this, `fix` errors with a hint to run init. The point is to
+    # avoid creating directories on the user's machine without their
+    # explicit consent.
+    class Init
+      USAGE = <<~USAGE
+        Usage: gem-contribute init
+
+        Interactively set the directory where forks are cloned (clone_root).
+        Re-run any time to change.
+      USAGE
+
+      DEFAULT_SUGGESTION = "~/code/oss"
+
+      def initialize(stdout: $stdout, stderr: $stderr,
+                     config: GemContribute::Config.new,
+                     gets: -> { $stdin.gets })
+        @stdout = stdout
+        @stderr = stderr
+        @config = config
+        @gets = gets
+      end
+
+      def run(argv)
+        return print_usage if %w[help -h --help].include?(argv.first)
+
+        current = @config.to_h["clone_root"]
+        default = current || DEFAULT_SUGGESTION
+
+        @stdout.print "Where should I clone repos? [#{default}]: "
+        @stdout.flush
+        input = @gets.call.to_s.chomp.strip
+        chosen = input.empty? ? default : input
+
+        @config.set("clone_root", chosen)
+        @stdout.puts "Clone root set to #{File.expand_path(chosen)}"
+        @stdout.puts "Re-run `gem-contribute init` any time to change this."
+        0
+      end
+
+      private
+
+      def print_usage
+        @stdout.puts USAGE
+        0
+      end
+    end
+  end
+end

--- a/lib/gem_contribute/cli/init.rb
+++ b/lib/gem_contribute/cli/init.rb
@@ -2,34 +2,48 @@
 
 module GemContribute
   module CLI
-    # `gem-contribute init` — interactive one-time setup that writes the
-    # user's `clone_root` to ~/.config/gem-contribute/config.yml.
+    # `gem-contribute init` — interactive one-time setup. Writes the user's
+    # `clone_root` to ~/.config/gem-contribute/config.yml and, if no GitHub
+    # token is cached, offers to run `auth login`.
     #
-    # Without this, `fix` errors with a hint to run init. The point is to
-    # avoid creating directories on the user's machine without their
-    # explicit consent.
+    # Without init, `fix` errors with a hint to run init. The point is to
+    # avoid creating directories or assuming auth without explicit consent.
     class Init
       USAGE = <<~USAGE
         Usage: gem-contribute init
 
-        Interactively set the directory where forks are cloned (clone_root).
+        Interactively set the directory where forks are cloned (clone_root),
+        then offer to authenticate with GitHub if you haven't already.
         Re-run any time to change.
       USAGE
 
       DEFAULT_SUGGESTION = "~/code/oss"
+      AUTH_HOST = "github.com"
 
       def initialize(stdout: $stdout, stderr: $stderr,
                      config: GemContribute::Config.new,
+                     store: GemContribute::TokenStore.new,
+                     auth: nil,
                      gets: -> { $stdin.gets })
         @stdout = stdout
         @stderr = stderr
         @config = config
+        @store = store
+        @auth = auth || GemContribute::CLI::Auth.new(stdout: stdout, stderr: stderr, store: store)
         @gets = gets
       end
 
       def run(argv)
         return print_usage if %w[help -h --help].include?(argv.first)
 
+        prompt_clone_root
+        maybe_authenticate
+        0
+      end
+
+      private
+
+      def prompt_clone_root
         current = @config.to_h["clone_root"]
         default = current || DEFAULT_SUGGESTION
 
@@ -40,11 +54,25 @@ module GemContribute
 
         @config.set("clone_root", chosen)
         @stdout.puts "Clone root set to #{File.expand_path(chosen)}"
-        @stdout.puts "Re-run `gem-contribute init` any time to change this."
-        0
       end
 
-      private
+      def maybe_authenticate
+        if @store.token_for(AUTH_HOST)
+          @stdout.puts "GitHub: already authenticated."
+          return
+        end
+
+        @stdout.print "Authenticate with GitHub now? [Y/n]: "
+        @stdout.flush
+        answer = @gets.call.to_s.chomp.strip.downcase
+
+        if %w[n no].include?(answer)
+          @stdout.puts "Skipping auth. Run `gem-contribute auth login` when you're ready."
+          return
+        end
+
+        @auth.run(["login"])
+      end
 
       def print_usage
         @stdout.puts USAGE

--- a/lib/gem_contribute/config.rb
+++ b/lib/gem_contribute/config.rb
@@ -8,8 +8,6 @@ module GemContribute
   # Honors XDG_CONFIG_HOME so tests stay hermetic and unusual layouts work.
   # Missing or corrupt files are treated as an empty config (no crash).
   class Config
-    DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
-
     KNOWN_KEYS = %w[clone_root].freeze
 
     def initialize(path: self.class.default_path)
@@ -19,7 +17,7 @@ module GemContribute
 
     def clone_root
       raw = @data["clone_root"]
-      raw ? File.expand_path(raw) : DEFAULT_CLONE_ROOT
+      raw ? File.expand_path(raw) : nil
     end
 
     def set(key, value)

--- a/spec/gem_contribute/cli/fork_clone_branch_spec.rb
+++ b/spec/gem_contribute/cli/fork_clone_branch_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe GemContribute::CLI::ForkCloneBranch do
     expect(stderr.string).to include("auth login")
   end
 
+  it "exits 1 with an init hint when clone_root is nil" do
+    cli_no_clone_root = described_class.new(
+      stdout: stdout, stderr: stderr,
+      resolver: resolver, store: store,
+      adapter_factory: ->(**) { adapter },
+      git: git, clone_root: nil,
+      sleeper: ->(_s) {}
+    )
+    expect(cli_no_clone_root.run(["sidekiq/1"])).to eq(1)
+    expect(stderr.string).to include("gem-contribute init")
+  end
+
   it "forks, polls until ready, clones, and branches when no fork exists yet", :aggregate_failures do
     allow(adapter).to receive(:viewer_login).and_return("alice")
     allow(adapter).to receive(:already_forked?).with(project).and_return(false)

--- a/spec/gem_contribute/cli/init_spec.rb
+++ b/spec/gem_contribute/cli/init_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe GemContribute::CLI::Init do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:tmpdir) { Dir.mktmpdir("gem-contribute-cli-init-") }
+  let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
+  let(:input) { "" }
+  let(:cli) do
+    described_class.new(
+      stdout: stdout, stderr: stderr,
+      config: config, gets: -> { input }
+    )
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "writes the default suggestion when the user accepts with Enter" do
+    expect(cli.run([])).to eq(0)
+    expect(stdout.string).to include("[~/code/oss]")
+    expect(config.clone_root).to eq(File.expand_path("~/code/oss"))
+    expect(stdout.string).to include("Clone root set to")
+  end
+
+  context "with a custom path" do
+    let(:input) { "~/projects/oss\n" }
+
+    it "writes the user-supplied path" do
+      expect(cli.run([])).to eq(0)
+      expect(config.clone_root).to eq(File.expand_path("~/projects/oss"))
+      expect(stdout.string).to include("Clone root set to #{File.expand_path("~/projects/oss")}")
+    end
+  end
+
+  context "when re-run with a value already set" do
+    before { config.set("clone_root", "/srv/oss") }
+
+    it "shows the existing value as the default" do
+      expect(cli.run([])).to eq(0)
+      expect(stdout.string).to include("[/srv/oss]")
+    end
+
+    context "when the user accepts the existing value" do
+      let(:input) { "" }
+
+      it "keeps the existing value" do
+        expect(cli.run([])).to eq(0)
+        expect(config.clone_root).to eq("/srv/oss")
+      end
+    end
+
+    context "when the user supplies a new value" do
+      let(:input) { "/new/path\n" }
+
+      it "overwrites the existing value" do
+        expect(cli.run([])).to eq(0)
+        expect(config.clone_root).to eq("/new/path")
+      end
+    end
+  end
+
+  it "prints usage on --help" do
+    expect(cli.run(["--help"])).to eq(0)
+    expect(stdout.string).to include("Usage:")
+  end
+end

--- a/spec/gem_contribute/cli/init_spec.rb
+++ b/spec/gem_contribute/cli/init_spec.rb
@@ -7,56 +7,104 @@ RSpec.describe GemContribute::CLI::Init do
   let(:stderr) { StringIO.new }
   let(:tmpdir) { Dir.mktmpdir("gem-contribute-cli-init-") }
   let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
-  let(:input) { "" }
+  let(:store) { GemContribute::TokenStore.new(path: File.join(tmpdir, "auth.json")) }
+  let(:auth) { instance_double(GemContribute::CLI::Auth) }
+  let(:inputs) { [""] }
   let(:cli) do
     described_class.new(
       stdout: stdout, stderr: stderr,
-      config: config, gets: -> { input }
+      config: config, store: store, auth: auth,
+      gets: -> { inputs.shift }
     )
   end
 
+  before { allow(auth).to receive(:run).and_return(0) }
   after { FileUtils.rm_rf(tmpdir) }
 
-  it "writes the default suggestion when the user accepts with Enter" do
-    expect(cli.run([])).to eq(0)
-    expect(stdout.string).to include("[~/code/oss]")
-    expect(config.clone_root).to eq(File.expand_path("~/code/oss"))
-    expect(stdout.string).to include("Clone root set to")
-  end
+  context "when already authenticated" do
+    before { store.store("github.com", access_token: "gho_test") }
 
-  context "with a custom path" do
-    let(:input) { "~/projects/oss\n" }
-
-    it "writes the user-supplied path" do
+    it "writes the default suggestion when the user accepts with Enter" do
       expect(cli.run([])).to eq(0)
-      expect(config.clone_root).to eq(File.expand_path("~/projects/oss"))
-      expect(stdout.string).to include("Clone root set to #{File.expand_path("~/projects/oss")}")
-    end
-  end
-
-  context "when re-run with a value already set" do
-    before { config.set("clone_root", "/srv/oss") }
-
-    it "shows the existing value as the default" do
-      expect(cli.run([])).to eq(0)
-      expect(stdout.string).to include("[/srv/oss]")
+      expect(stdout.string).to include("[~/code/oss]")
+      expect(config.clone_root).to eq(File.expand_path("~/code/oss"))
+      expect(stdout.string).to include("Clone root set to")
+      expect(stdout.string).to include("already authenticated")
+      expect(auth).not_to have_received(:run)
     end
 
-    context "when the user accepts the existing value" do
-      let(:input) { "" }
+    context "with a custom path" do
+      let(:inputs) { ["~/projects/oss\n"] }
 
-      it "keeps the existing value" do
+      it "writes the user-supplied path" do
         expect(cli.run([])).to eq(0)
-        expect(config.clone_root).to eq("/srv/oss")
+        expect(config.clone_root).to eq(File.expand_path("~/projects/oss"))
       end
     end
 
-    context "when the user supplies a new value" do
-      let(:input) { "/new/path\n" }
+    context "when re-run with a value already set" do
+      before { config.set("clone_root", "/srv/oss") }
 
-      it "overwrites the existing value" do
+      it "shows the existing value as the default" do
         expect(cli.run([])).to eq(0)
-        expect(config.clone_root).to eq("/new/path")
+        expect(stdout.string).to include("[/srv/oss]")
+      end
+
+      context "when the user accepts the existing value" do
+        let(:inputs) { [""] }
+
+        it "keeps the existing value" do
+          expect(cli.run([])).to eq(0)
+          expect(config.clone_root).to eq("/srv/oss")
+        end
+      end
+
+      context "when the user supplies a new value" do
+        let(:inputs) { ["/new/path\n"] }
+
+        it "overwrites the existing value" do
+          expect(cli.run([])).to eq(0)
+          expect(config.clone_root).to eq("/new/path")
+        end
+      end
+    end
+  end
+
+  context "when not authenticated" do
+    context "when the user accepts the auth prompt with Enter" do
+      let(:inputs) { ["", ""] }
+
+      it "runs auth login" do
+        expect(cli.run([])).to eq(0)
+        expect(auth).to have_received(:run).with(["login"])
+      end
+    end
+
+    context "when the user accepts the auth prompt with 'y'" do
+      let(:inputs) { ["", "y"] }
+
+      it "runs auth login" do
+        expect(cli.run([])).to eq(0)
+        expect(auth).to have_received(:run).with(["login"])
+      end
+    end
+
+    context "when the user declines with 'n'" do
+      let(:inputs) { ["", "n"] }
+
+      it "skips auth login and prints a hint" do
+        expect(cli.run([])).to eq(0)
+        expect(auth).not_to have_received(:run)
+        expect(stdout.string).to include("Skipping auth")
+      end
+    end
+
+    context "when the user declines with 'no'" do
+      let(:inputs) { ["", "no"] }
+
+      it "skips auth login" do
+        expect(cli.run([])).to eq(0)
+        expect(auth).not_to have_received(:run)
       end
     end
   end

--- a/spec/gem_contribute/config_spec.rb
+++ b/spec/gem_contribute/config_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe GemContribute::Config do
   after { FileUtils.rm_rf(tmpdir) }
 
   describe "#clone_root" do
-    it "returns the default when no config file exists" do
-      expect(config.clone_root).to eq(File.expand_path("~/code/oss"))
+    it "returns nil when no config file exists" do
+      expect(config.clone_root).to be_nil
     end
 
     it "returns the configured value with ~ expanded" do
@@ -49,6 +49,6 @@ RSpec.describe GemContribute::Config do
   it "treats a corrupt config file as empty rather than crashing" do
     File.write(path, ":::not valid yaml:::")
     expect { described_class.new(path: path) }.not_to raise_error
-    expect(described_class.new(path: path).clone_root).to eq(File.expand_path("~/code/oss"))
+    expect(described_class.new(path: path).clone_root).to be_nil
   end
 end


### PR DESCRIPTION
## Summary

Add `gem-contribute init` — interactive one-time setup that sets `clone_root` and, when no GitHub token is cached, offers to chain `auth login`. Remove the silent fallback to `~/code/oss` so first-time users aren't surprised by directory creation. Closes #15.

## Review preference

- [ ] **Ship it.** Review for correctness, tests, and design fit. Skip style nits unless they're load-bearing.
- [x] **Full review, please.** Feedback on style, naming, idioms, and alternative designs welcome. I want the deep version, whether to learn the Ruby way or to stress-test a pattern I'm trying.

## Working agreement check

- [x] Single concern (`init` setup flow + the breaking change it justifies).
- [x] ADRs touched: none. UX change rather than an architectural decision.
- [x] `bin/rubocop` and `bin/rspec` pass locally (143 examples, 0 failures; rubocop clean across the files this PR touches).
- [x] New behavior has a test; the breaking error path has a regression test.
- [x] Async work goes through Rooibos Commands — N/A, no async work added.

## Notes for reviewer

- **`Config::DEFAULT_CLONE_ROOT` is removed.** Nothing else referenced it, and keeping it as documentation alongside the new "no silent default" behavior would be misleading. `ForkCloneBranch::DEFAULT_CLONE_ROOT` (separate constant inside that class, only used as a constructor default arg for tests) is left alone.
- **Auth chain design:** if a token is already cached for `github.com`, `init` skips the auth step entirely (local `TokenStore` check, no API call). Otherwise it prompts `Authenticate with GitHub now? [Y/n]` — Enter or `y` runs `auth login`; `n`/`no` skips with a hint. This keeps re-running `init` cheap for already-authed users and makes the (long, interactive) device-flow opt-in for new users.
- **`Init` injects `store:` and `auth:`** in addition to `gets:` so specs can stub the auth boundary without touching disk or the network.
- **Error message in `fork-clone-branch`** is `clone_root is not configured. Run `gem-contribute init` first.` — friendly and points at the fix.
- **`cli/config.rb` collateral updates:** `get` and `list` now print `(not set; run gem-contribute init)` when there's no value, and the USAGE text for `clone_root` mentions both `init` and `config set` as the way to set it.
- **Two pre-existing rubocop offenses** in `spec/gem_contribute/cli/issues_spec.rb` and `spec/gem_contribute/cli/scan_spec.rb` are not addressed here per the single-concern rule. Happy to file as a separate cleanup issue if wanted.
- **The "Rooibos Commands" wording** in this template predates [ADR-0010](https://github.com/cdhagmann/gem-contribute/blob/main/docs/adr/0010-charm-ruby-tui-framework.md) (which supersedes ADR-0008). A separate ADR-rollout PR should update CLAUDE.md, this template, and the gemspec.