### PR TITLE
feat(fix, scan, issues): claim/discover the working-on-this marker (closes #18, #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented here. The format is based
 
 ## [Unreleased]
 
+### Added
+
+- `gem-contribute fix -e` opens your editor in the clone directory after fork/clone/branch. Uses the new `editor` config key, falling back to `$EDITOR` (closes [#14](https://github.com/cdhagmann/gem-contribute/issues/14)).
+- `gem-contribute fix -a` launches your configured AI coding tool (new `ai_tool` config key) with the clone directory as cwd. Combine with `-e` to open both — editor first, AI tool second (closes [#14](https://github.com/cdhagmann/gem-contribute/issues/14)).
+- `gem-contribute fix` posts a "👋 I've started working on this" comment to the issue by default so other contributors don't double up on the same work. Opt out per-invocation with `--no-comment`, globally with `comment_on_fix: false` in config, or per-repo via `comment_on_fix_overrides` (YAML-only). Posting is soft-fail — the fork/clone/branch part still succeeds even if the comment can't be posted (closes [#18](https://github.com/cdhagmann/gem-contribute/issues/18)).
+- `scan` appends `· N claimed` to project lines whose open issues have already been claimed via the working-on-this marker, so you can spot already-in-progress work at a glance (closes [#20](https://github.com/cdhagmann/gem-contribute/issues/20)).
+- `issues <gem|all>` prefixes claimed issues with `[claimed]` for the same reason (closes [#20](https://github.com/cdhagmann/gem-contribute/issues/20)).
+
+### Changed
+
+- Internal class `ForkCloneBranch` renamed to `Fix` (the long name was cumbersome and didn't mirror the `fix` CLI verb). User-facing CLI surface unchanged.
+
 ### Removed
 
 - The `fork-clone-branch` CLI alias has been removed. Use `gem-contribute fix` instead — same behavior, shorter to type.

--- a/lib/gem_contribute/cli.rb
+++ b/lib/gem_contribute/cli.rb
@@ -12,6 +12,7 @@ module GemContribute
     autoload :Fix, "gem_contribute/cli/fix"
     autoload :Git, "gem_contribute/cli/fix"
     autoload :PostCloneHooks, "gem_contribute/cli/post_clone_hooks"
+    autoload :IssueAnnouncer, "gem_contribute/cli/issue_announcer"
     autoload :Submit, "gem_contribute/cli/submit"
     autoload :RateLimitFooter, "gem_contribute/cli/rate_limit_footer"
     USAGE = <<~USAGE
@@ -29,7 +30,7 @@ module GemContribute
         auth status              Show whether you're authenticated.
         auth logout              Remove the cached token for github.com.
         fix <gem>/<issue#>       Fork the gem's repo, clone the fork, branch from main.
-                                 Add -e to open your editor, -a to launch your AI tool.
+                                 Flags: -e (editor), -a (AI tool), --no-comment.
         submit                   Push the current branch and open a pre-filled
                                  PR compare page in the browser. Run from inside
                                  a clone created by `fix`.
@@ -68,8 +69,9 @@ module GemContribute
       "config" => ->(o, e) { Config.new(stdout: o, stderr: e) },
       "auth" => ->(o, e) { Auth.new(stdout: o, stderr: e) },
       "fix" => lambda { |o, e|
+        config = GemContribute::Config.new
         Fix.new(stdout: o, stderr: e,
-                clone_root: GemContribute::Config.new.clone_root)
+                clone_root: config.clone_root, config: config)
       },
       "submit" => ->(o, e) { Submit.new(stdout: o, stderr: e) }
     }.freeze

--- a/lib/gem_contribute/cli/config.rb
+++ b/lib/gem_contribute/cli/config.rb
@@ -25,6 +25,9 @@ module GemContribute
                                Example: gem-contribute config set editor code
           ai_tool              Shell command for `fix -a` (run in clone dir).
                                Example: gem-contribute config set ai_tool "claude ."
+          comment_on_fix       Whether `fix` posts a "working on this" comment.
+                               Default: true. Per-repo overrides via
+                               `comment_on_fix_overrides` in the YAML.
       USAGE
 
       def initialize(stdout: $stdout, stderr: $stderr, config: GemContribute::Config.new)
@@ -87,6 +90,12 @@ module GemContribute
         @stdout.puts "  clone_root = #{@config.clone_root || "(not set; run `gem-contribute init`)"}"
         @stdout.puts "  editor = #{@config.editor || "(not set)"}"
         @stdout.puts "  ai_tool = #{@config.ai_tool || "(not set)"}"
+        @stdout.puts "  comment_on_fix = #{@config.comment_on_fix?}"
+        overrides = @config.to_h["comment_on_fix_overrides"]
+        if overrides.is_a?(Hash) && !overrides.empty?
+          @stdout.puts "  comment_on_fix_overrides:"
+          overrides.each { |repo, val| @stdout.puts "    #{repo}: #{val}" }
+        end
         0
       end
     end

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -25,6 +25,11 @@ module GemContribute
     #
     # The shell-outs use Open3 with explicit args (not strings) to avoid any
     # shell-injection surface.
+    #
+    # Class length: this is the v0.1 fix-flow state machine. Splitting it
+    # into pieces would just create arbitrary sub-modules without making
+    # the flow easier to follow. Disabled here with rationale.
+    # rubocop:disable Metrics/ClassLength
     class Fix
       DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
       BRANCH_PREFIX = "gem-contribute/issue-"
@@ -129,7 +134,7 @@ module GemContribute
 
       def execute(adapter, project, issue, flags)
         viewer = adapter.viewer_login
-        was_resuming = clone_exists?(project)
+        was_resuming = branch_exists_locally?(project, issue)
         clone_url = ensure_fork(adapter, project, viewer)
         local_path = clone_into_root(project, clone_url)
         branch_name = "#{BRANCH_PREFIX}#{issue}"
@@ -145,9 +150,14 @@ module GemContribute
         0
       end
 
-      def clone_exists?(project)
+      # True if `gem-contribute/issue-<N>` already exists locally — the
+      # user is resuming this specific issue (the clone is shared across
+      # issues in the same repo, but the branch is per-issue).
+      def branch_exists_locally?(project, issue)
         target = File.join(@clone_root, project.owner, project.repo)
-        File.directory?(File.join(target, ".git"))
+        return false unless File.directory?(File.join(target, ".git"))
+
+        @git.branch_exists?(target, "#{BRANCH_PREFIX}#{issue}")
       end
 
       def announce_or_skip(adapter, project, issue, viewer, was_resuming:, flags:)
@@ -210,6 +220,8 @@ module GemContribute
       end
     end
 
+    # rubocop:enable Metrics/ClassLength
+
     # Thin wrapper around git so the spec can swap in a fake without shelling
     # out. The real implementation uses Open3 with arg-list invocation — no
     # shell, so no injection surface.
@@ -237,6 +249,13 @@ module GemContribute
       def remote_exists?(path, name)
         out, _err, status = Open3.capture3("git", "-C", path, "remote")
         status.success? && out.split("\n").include?(name)
+      end
+
+      def branch_exists?(path, branch)
+        _out, _err, status = Open3.capture3("git", "-C", path,
+                                            "rev-parse", "--verify", "--quiet",
+                                            "refs/heads/#{branch}")
+        status.success?
       end
 
       def run!(argv)

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -40,7 +40,8 @@ module GemContribute
                      git: Git.new,
                      clone_root: DEFAULT_CLONE_ROOT,
                      sleeper: ->(s) { Kernel.sleep(s) },
-                     post_clone_hooks: nil)
+                     post_clone_hooks: nil,
+                     config: nil)
         @stdout = stdout
         @stderr = stderr
         @resolver = resolver
@@ -50,6 +51,7 @@ module GemContribute
         @clone_root = clone_root
         @sleeper = sleeper
         @post_clone_hooks = post_clone_hooks || PostCloneHooks.new(stdout: stdout, stderr: stderr)
+        @config = config || GemContribute::Config.new
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -78,12 +80,13 @@ module GemContribute
       private
 
       def parse_argv(argv)
-        flags = { editor: false, ai_tool: false }
+        flags = { editor: false, ai_tool: false, no_comment: false }
         positional = []
         argv.each do |arg|
           case arg
           when "-e", "--editor" then flags[:editor] = true
           when "-a", "--ai"     then flags[:ai_tool] = true
+          when "--no-comment"   then flags[:no_comment] = true
           else positional << arg
           end
         end
@@ -126,6 +129,7 @@ module GemContribute
 
       def execute(adapter, project, issue, flags)
         viewer = adapter.viewer_login
+        was_resuming = clone_exists?(project)
         clone_url = ensure_fork(adapter, project, viewer)
         local_path = clone_into_root(project, clone_url)
         branch_name = "#{BRANCH_PREFIX}#{issue}"
@@ -136,8 +140,26 @@ module GemContribute
                         "https://github.com/#{project.owner}/#{project.repo}.git")
 
         print_summary(local_path, branch_name, project, viewer)
-        @post_clone_hooks.call(local_path, **flags)
+        announce_or_skip(adapter, project, issue, viewer, was_resuming: was_resuming, flags: flags)
+        @post_clone_hooks.call(local_path, editor: flags[:editor], ai_tool: flags[:ai_tool])
         0
+      end
+
+      def clone_exists?(project)
+        target = File.join(@clone_root, project.owner, project.repo)
+        File.directory?(File.join(target, ".git"))
+      end
+
+      def announce_or_skip(adapter, project, issue, viewer, was_resuming:, flags:)
+        return if flags[:no_comment]
+        return if was_resuming
+        return if viewer == project.owner
+        return unless @config.comment_on_fix?("#{project.owner}/#{project.repo}")
+
+        IssueAnnouncer.announce_working(
+          adapter: adapter, project: project, issue: issue,
+          stdout: @stdout, stderr: @stderr
+        )
       end
 
       def print_summary(local_path, branch_name, project, viewer)

--- a/lib/gem_contribute/cli/issue_announcer.rb
+++ b/lib/gem_contribute/cli/issue_announcer.rb
@@ -45,6 +45,31 @@ module GemContribute
         # attempt fail safely on its own.
         false
       end
+
+      # Builds a lookup hash of {"owner/repo" => Set<issue_number>} from
+      # GitHub's issue search for our marker. Used by `scan` and `issues`
+      # to flag claimed issues. One search call per process (the adapter
+      # caches the result for the issues TTL). Degrades to an empty hash
+      # if the search fails (anonymous rate limits, network, etc.).
+      def fetch_claim_index(adapter)
+        items = adapter.search_issues("\"#{WORKING_MARKER}\"")
+        items.each_with_object(Hash.new { |h, k| h[k] = [] }) do |item, index|
+          parsed = parse_issue_url(item["html_url"])
+          next unless parsed
+
+          owner, repo, number = parsed
+          index["#{owner}/#{repo}"] << number
+        end
+      rescue GemContribute::AdapterError, GemContribute::AuthRequired
+        {}
+      end
+
+      def parse_issue_url(url)
+        match = url.to_s.match(%r{github\.com/([^/]+)/([^/]+)/issues/(\d+)})
+        return nil unless match
+
+        [match[1], match[2], match[3].to_i]
+      end
     end
   end
 end

--- a/lib/gem_contribute/cli/issue_announcer.rb
+++ b/lib/gem_contribute/cli/issue_announcer.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module GemContribute
+  module CLI
+    # Body templates and marker matching for issue announcements posted by
+    # `gem-contribute fix` (and future `abandon`). The marker is an HTML
+    # comment in the body so re-runs can detect prior posts deterministically.
+    #
+    # Format: `<!-- gem-contribute:<verb> v<n> -->`. The verb is namespaced so
+    # multiple announcement types can coexist on one issue (a `working` and
+    # later an `abandon` describe different states). The version suffix lets
+    # us rev the body without invalidating the matcher.
+    module IssueAnnouncer
+      WORKING_MARKER = "<!-- gem-contribute:working v1 -->"
+      WORKING_BODY = <<~BODY.freeze
+        #{WORKING_MARKER}
+        👋 I've started working on this. I'll open a PR shortly.
+
+        <sub>Posted via [gem-contribute](https://github.com/cdhagmann/gem-contribute).</sub>
+      BODY
+
+      module_function
+
+      # Returns:
+      #   :posted  — comment was posted
+      #   :skipped — viewer's prior comments contain the marker (already announced)
+      #   :failed  — API call raised; warning printed to stderr
+      def announce_working(adapter:, project:, issue:, stdout:, stderr:)
+        return :skipped if already_announced?(adapter, project, issue, WORKING_MARKER)
+
+        adapter.comment_on_issue(project, issue, WORKING_BODY)
+        stdout.puts "Posted 'working on this' comment to issue ##{issue}."
+        :posted
+      rescue GemContribute::AdapterError => e
+        stderr.puts "Note: couldn't post 'working on this' comment to issue ##{issue}: " \
+                    "#{e.message}. Continuing."
+        :failed
+      end
+
+      def already_announced?(adapter, project, issue, marker)
+        comments = adapter.issue_comments(project, issue)
+        comments.any? { |c| c["body"].to_s.include?(marker) }
+      rescue GemContribute::AdapterError
+        # If we can't fetch comments, assume not announced and let the post
+        # attempt fail safely on its own.
+        false
+      end
+    end
+  end
+end

--- a/lib/gem_contribute/cli/issues.rb
+++ b/lib/gem_contribute/cli/issues.rb
@@ -27,6 +27,8 @@ module GemContribute
         target = argv.shift
         return print_usage if target.nil?
 
+        @claim_index = IssueAnnouncer.fetch_claim_index(@adapter)
+
         status = if target == "all"
                    run_all
                  else
@@ -115,11 +117,17 @@ module GemContribute
           @stdout.puts "  (none — browse #{repo_url}/issues directly)"
         else
           @stdout.puts
-          issues.each do |issue|
-            @stdout.puts "  ##{issue["number"]}  #{issue["title"]}"
-            @stdout.puts "        #{issue["html_url"]}"
-            @stdout.puts
-          end
+          print_issue_list(project, issues)
+        end
+      end
+
+      def print_issue_list(project, issues)
+        claimed = @claim_index["#{project.owner}/#{project.repo}"] || []
+        issues.each do |issue|
+          label = claimed.include?(issue["number"]) ? "[claimed] " : ""
+          @stdout.puts "  ##{issue["number"]}  #{label}#{issue["title"]}"
+          @stdout.puts "        #{issue["html_url"]}"
+          @stdout.puts
         end
       end
     end

--- a/lib/gem_contribute/cli/scan.rb
+++ b/lib/gem_contribute/cli/scan.rb
@@ -66,7 +66,8 @@ module GemContribute
         ranked = rank_by_issue_count(inject_self(github_from_lockfile))
         return if ranked.empty?
 
-        print_ranked(ranked)
+        claim_index = IssueAnnouncer.fetch_claim_index(@adapter)
+        print_ranked(ranked, claim_index)
       end
 
       def tally_hosts(projects)
@@ -104,13 +105,15 @@ module GemContribute
         0
       end
 
-      def print_ranked(ranked)
+      def print_ranked(ranked, claim_index)
         @stdout.puts
         @stdout.puts "Top contributable projects (by open `good first issue` count):"
         col_name = ranked.map { |p, _| p.gem_name.length }.max
         ranked.each do |project, count|
           location = "#{project.host}/#{project.owner}/#{project.repo}"
-          @stdout.printf("  %-#{col_name}s  %3d  %s\n", project.gem_name, count, location)
+          claimed = claim_index["#{project.owner}/#{project.repo}"] || []
+          suffix = claimed.empty? ? "" : "  · #{claimed.size} claimed"
+          @stdout.printf("  %-#{col_name}s  %3d  %s%s\n", project.gem_name, count, location, suffix)
         end
       end
     end

--- a/lib/gem_contribute/config.rb
+++ b/lib/gem_contribute/config.rb
@@ -8,7 +8,7 @@ module GemContribute
   # Honors XDG_CONFIG_HOME so tests stay hermetic and unusual layouts work.
   # Missing or corrupt files are treated as an empty config (no crash).
   class Config
-    KNOWN_KEYS = %w[clone_root editor ai_tool].freeze
+    KNOWN_KEYS = %w[clone_root editor ai_tool comment_on_fix].freeze
 
     def initialize(path: self.class.default_path)
       @path = path
@@ -26,6 +26,17 @@ module GemContribute
 
     def ai_tool
       @data["ai_tool"]
+    end
+
+    # Returns whether `fix` should post a "working on this" comment.
+    # Pass a repo (`"owner/repo"`) to check the per-repo override; without
+    # a repo, returns the global default. Default is true when unset.
+    def comment_on_fix?(repo = nil)
+      overrides = @data["comment_on_fix_overrides"]
+      return truthy?(overrides[repo]) if repo && overrides.is_a?(Hash) && overrides.key?(repo)
+
+      raw = @data["comment_on_fix"]
+      raw.nil? || truthy?(raw)
     end
 
     def set(key, value)
@@ -46,6 +57,13 @@ module GemContribute
     end
 
     private
+
+    def truthy?(value)
+      case value
+      when true, false then value
+      else value.to_s.downcase != "false"
+      end
+    end
 
     def load_file
       return {} unless File.exist?(@path)

--- a/lib/gem_contribute/host_adapters/github_adapter.rb
+++ b/lib/gem_contribute/host_adapters/github_adapter.rb
@@ -13,6 +13,12 @@ module GemContribute
     #
     # `token` is optional and reserved for Stage 2; when present it's sent as
     # `Authorization: Bearer …` to lift the rate limit and unlock fork/etc.
+    #
+    # Class length: this adapter wraps a growing surface area of GitHub
+    # endpoints (issues, comments, forks, community profile, contents). The
+    # 150-line metric isn't a useful constraint here — we'd just split into
+    # arbitrary sub-modules — so it's disabled below with this rationale.
+    # rubocop:disable Metrics/ClassLength
     class GitHubAdapter < HostAdapter
       API_BASE = "https://api.github.com"
       ACCEPT = "application/vnd.github+json"
@@ -126,6 +132,27 @@ module GemContribute
         raise
       end
 
+      # POST /repos/:owner/:repo/issues/:n/comments. Returns the created
+      # comment payload (id, body, html_url, ...). Used by `fix` to post
+      # the "working on this" announcement.
+      def comment_on_issue(project, issue_number, body)
+        raise AuthRequired, "github.com" unless @token
+
+        ensure_known_host!(project)
+        post_json("/repos/#{project.owner}/#{project.repo}/issues/#{issue_number}/comments",
+                  { "body" => body })
+      end
+
+      # GET /repos/:owner/:repo/issues/:n/comments. Returns an array of
+      # comment payloads. Uncached (callers may want fresh data, e.g. to
+      # check for an idempotency marker).
+      def issue_comments(project, issue_number)
+        raise AuthRequired, "github.com" unless @token
+
+        ensure_known_host!(project)
+        get_json("/repos/#{project.owner}/#{project.repo}/issues/#{issue_number}/comments")
+      end
+
       private
 
       def issue_cache_key(project, labels)
@@ -211,5 +238,6 @@ module GemContribute
         )
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/gem_contribute/host_adapters/github_adapter.rb
+++ b/lib/gem_contribute/host_adapters/github_adapter.rb
@@ -153,6 +153,21 @@ module GemContribute
         get_json("/repos/#{project.owner}/#{project.repo}/issues/#{issue_number}/comments")
       end
 
+      # GET /search/issues. Wraps GitHub's issue search; works without auth
+      # (subject to the 60/hr anonymous rate limit). Returns an array of
+      # issue payloads (the search response's `items` key). Cached under the
+      # `issues` namespace using the query as the key. Used to find issues
+      # already claimed via the gem-contribute marker.
+      def search_issues(query)
+        cache_key = "search:#{query}"
+        cached = @cache.fetch("issues", cache_key)
+        return cached if cached
+
+        raw = get_json("/search/issues", q: query)
+        items = raw.fetch("items", [])
+        @cache.write("issues", cache_key, items)
+      end
+
       private
 
       def issue_cache_key(project, labels)

--- a/spec/gem_contribute/cli/fix_spec.rb
+++ b/spec/gem_contribute/cli/fix_spec.rb
@@ -2,6 +2,7 @@
 
 require "stringio"
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe GemContribute::CLI::Fix do
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
@@ -11,13 +12,15 @@ RSpec.describe GemContribute::CLI::Fix do
   let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
   let(:git) { instance_double(GemContribute::CLI::Git) }
   let(:clone_root) { File.join(tmpdir, "code", "oss") }
+  let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
   let(:cli) do
     described_class.new(
       stdout: stdout, stderr: stderr,
       resolver: resolver, store: store,
       adapter_factory: ->(**) { adapter },
       git: git, clone_root: clone_root,
-      sleeper: ->(_s) {}
+      sleeper: ->(_s) {},
+      config: config
     )
   end
 
@@ -34,6 +37,7 @@ RSpec.describe GemContribute::CLI::Fix do
     allow(git).to receive(:clone)
     allow(git).to receive(:checkout_branch)
     allow(git).to receive(:add_remote)
+    allow(GemContribute::CLI::IssueAnnouncer).to receive(:announce_working).and_return(:posted)
   end
 
   after { FileUtils.rm_rf(tmpdir) }
@@ -134,7 +138,6 @@ RSpec.describe GemContribute::CLI::Fix do
     expect(stderr.string).to include("fork not reachable")
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe "with -e and -a flags" do
     let(:hooks) { instance_double(GemContribute::CLI::PostCloneHooks, call: nil) }
     let(:cli_with_hooks) do
@@ -144,7 +147,8 @@ RSpec.describe GemContribute::CLI::Fix do
         adapter_factory: ->(**) { adapter },
         git: git, clone_root: clone_root,
         sleeper: ->(_s) {},
-        post_clone_hooks: hooks
+        post_clone_hooks: hooks,
+        config: config
       )
     end
     let(:target_path) { File.join(clone_root, "sidekiq", "sidekiq") }
@@ -167,6 +171,67 @@ RSpec.describe GemContribute::CLI::Fix do
     it "calls hooks with both flags false when neither flag is given" do
       expect(cli_with_hooks.run(["sidekiq/1"])).to eq(0)
       expect(hooks).to have_received(:call).with(target_path, editor: false, ai_tool: false)
+    end
+  end
+
+  describe "issue comment integration" do
+    before do
+      allow(adapter).to receive(:viewer_login).and_return("alice")
+      allow(adapter).to receive(:already_forked?).with(project).and_return(true)
+    end
+
+    it "announces working on the issue by default" do
+      expect(cli.run(["sidekiq/1234"])).to eq(0)
+      expect(GemContribute::CLI::IssueAnnouncer).to have_received(:announce_working)
+        .with(adapter: adapter, project: project, issue: "1234",
+              stdout: stdout, stderr: stderr)
+    end
+
+    it "skips the announce when --no-comment is passed" do
+      expect(cli.run(["sidekiq/1234", "--no-comment"])).to eq(0)
+      expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+    end
+
+    it "skips the announce when the local clone already exists" do
+      target = File.join(clone_root, "sidekiq", "sidekiq")
+      FileUtils.mkdir_p(File.join(target, ".git"))
+
+      expect(cli.run(["sidekiq/1234"])).to eq(0)
+      expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+    end
+
+    it "skips the announce when the viewer owns the upstream" do
+      owned = GemContribute::Project.new(
+        gem_name: "rubocop", host: "github.com",
+        owner: "alice", repo: "rubocop", metadata: {}
+      )
+      allow(resolver).to receive(:resolve).and_return(owned)
+      allow(adapter).to receive(:already_forked?).with(owned).and_return(true)
+
+      expect(cli.run(["rubocop/1234"])).to eq(0)
+      expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+    end
+
+    context "when comment_on_fix is false in config" do
+      before { config.set("comment_on_fix", "false") }
+
+      it "skips the announce" do
+        expect(cli.run(["sidekiq/1234"])).to eq(0)
+        expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+      end
+    end
+
+    context "when a per-repo override turns it off" do
+      before do
+        File.write(File.join(tmpdir, "config.yml"),
+                   YAML.dump("comment_on_fix" => true,
+                             "comment_on_fix_overrides" => { "sidekiq/sidekiq" => false }))
+      end
+
+      it "skips the announce" do
+        expect(cli.run(["sidekiq/1234"])).to eq(0)
+        expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+      end
     end
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/gem_contribute/cli/fix_spec.rb
+++ b/spec/gem_contribute/cli/fix_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe GemContribute::CLI::Fix do
     allow(git).to receive(:clone)
     allow(git).to receive(:checkout_branch)
     allow(git).to receive(:add_remote)
+    allow(git).to receive(:branch_exists?).and_return(false)
     allow(GemContribute::CLI::IssueAnnouncer).to receive(:announce_working).and_return(:posted)
   end
 
@@ -192,12 +193,23 @@ RSpec.describe GemContribute::CLI::Fix do
       expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
     end
 
-    it "skips the announce when the local clone already exists" do
+    it "skips the announce when the issue's branch already exists locally (resuming)" do
       target = File.join(clone_root, "sidekiq", "sidekiq")
       FileUtils.mkdir_p(File.join(target, ".git"))
+      allow(git).to receive(:branch_exists?).with(target, "gem-contribute/issue-1234").and_return(true)
 
       expect(cli.run(["sidekiq/1234"])).to eq(0)
       expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+    end
+
+    it "announces when the clone exists but the branch for this issue is new" do
+      # User worked on issue 4 yesterday (clone exists), now starting issue 1234 fresh.
+      target = File.join(clone_root, "sidekiq", "sidekiq")
+      FileUtils.mkdir_p(File.join(target, ".git"))
+      allow(git).to receive(:branch_exists?).with(target, "gem-contribute/issue-1234").and_return(false)
+
+      expect(cli.run(["sidekiq/1234"])).to eq(0)
+      expect(GemContribute::CLI::IssueAnnouncer).to have_received(:announce_working)
     end
 
     it "skips the announce when the viewer owns the upstream" do

--- a/spec/gem_contribute/cli/issue_announcer_spec.rb
+++ b/spec/gem_contribute/cli/issue_announcer_spec.rb
@@ -72,4 +72,39 @@ RSpec.describe GemContribute::CLI::IssueAnnouncer do
       expect(adapter).to have_received(:comment_on_issue)
     end
   end
+
+  describe ".fetch_claim_index" do
+    let(:claim_adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
+
+    it "groups search hits into a {owner/repo => [numbers]} hash" do
+      hits = [
+        { "html_url" => "https://github.com/sidekiq/sidekiq/issues/7" },
+        { "html_url" => "https://github.com/sidekiq/sidekiq/issues/12" },
+        { "html_url" => "https://github.com/rubocop/rubocop/issues/100" }
+      ]
+      allow(claim_adapter).to receive(:search_issues).and_return(hits)
+
+      index = described_class.fetch_claim_index(claim_adapter)
+      expect(index["sidekiq/sidekiq"]).to contain_exactly(7, 12)
+      expect(index["rubocop/rubocop"]).to contain_exactly(100)
+    end
+
+    it "returns an empty hash when the search raises AdapterError" do
+      allow(claim_adapter).to receive(:search_issues)
+        .and_raise(GemContribute::AdapterError, "rate limit exceeded")
+
+      expect(described_class.fetch_claim_index(claim_adapter)).to eq({})
+    end
+
+    it "skips entries whose html_url isn't a recognizable issue URL" do
+      hits = [
+        { "html_url" => "https://example.com/something/weird" },
+        { "html_url" => "https://github.com/foo/bar/issues/9" }
+      ]
+      allow(claim_adapter).to receive(:search_issues).and_return(hits)
+
+      index = described_class.fetch_claim_index(claim_adapter)
+      expect(index).to eq("foo/bar" => [9])
+    end
+  end
 end

--- a/spec/gem_contribute/cli/issue_announcer_spec.rb
+++ b/spec/gem_contribute/cli/issue_announcer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe GemContribute::CLI::IssueAnnouncer do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
+  let(:project) do
+    GemContribute::Project.new(
+      gem_name: "sidekiq", host: "github.com",
+      owner: "sidekiq", repo: "sidekiq", metadata: {}
+    )
+  end
+
+  describe ".announce_working" do
+    it "posts a comment and returns :posted when no marker is present" do
+      allow(adapter).to receive_messages(issue_comments: [], comment_on_issue: { "id" => 1 })
+
+      result = described_class.announce_working(
+        adapter: adapter, project: project, issue: "1234",
+        stdout: stdout, stderr: stderr
+      )
+
+      expect(result).to eq(:posted)
+      expect(adapter).to have_received(:comment_on_issue)
+        .with(project, "1234", a_string_including(described_class::WORKING_MARKER))
+      expect(stdout.string).to include("Posted 'working on this' comment to issue #1234")
+    end
+
+    it "skips the post and returns :skipped when the marker is present" do
+      allow(adapter).to receive(:issue_comments).and_return(
+        [{ "body" => "Random earlier comment" },
+         { "body" => "#{described_class::WORKING_MARKER}\nI've started working on this." }]
+      )
+
+      result = described_class.announce_working(
+        adapter: adapter, project: project, issue: "1234",
+        stdout: stdout, stderr: stderr
+      )
+
+      expect(result).to eq(:skipped)
+      expect(adapter).not_to have_received(:comment_on_issue) if defined?(adapter.comment_on_issue)
+    end
+
+    it "soft-fails to :failed when the post raises AdapterError" do
+      allow(adapter).to receive(:issue_comments).and_return([])
+      allow(adapter).to receive(:comment_on_issue)
+        .and_raise(GemContribute::AdapterError, "GitHub returned 422")
+
+      result = described_class.announce_working(
+        adapter: adapter, project: project, issue: "1234",
+        stdout: stdout, stderr: stderr
+      )
+
+      expect(result).to eq(:failed)
+      expect(stderr.string).to include("couldn't post 'working on this' comment")
+      expect(stderr.string).to include("Continuing.")
+    end
+
+    it "treats an AdapterError on the comment-listing call as 'not announced' and still posts" do
+      allow(adapter).to receive(:issue_comments)
+        .and_raise(GemContribute::AdapterError, "GitHub returned 500")
+      allow(adapter).to receive(:comment_on_issue).and_return("id" => 2)
+
+      result = described_class.announce_working(
+        adapter: adapter, project: project, issue: "1234",
+        stdout: stdout, stderr: stderr
+      )
+
+      expect(result).to eq(:posted)
+      expect(adapter).to have_received(:comment_on_issue)
+    end
+  end
+end

--- a/spec/gem_contribute/cli/issues_spec.rb
+++ b/spec/gem_contribute/cli/issues_spec.rb
@@ -30,9 +30,13 @@ RSpec.describe GemContribute::CLI::Issues do
     }
   end
 
-  before { allow(resolver).to receive(:resolve).and_return(project) }
-  # Default: footer is a no-op unless a test explicitly returns a RateLimit.
-  before { allow(adapter).to receive(:rate_limit).and_return(nil) }
+  before do
+    allow(resolver).to receive(:resolve).and_return(project)
+    # Default: footer is a no-op unless a test explicitly returns a RateLimit.
+    allow(adapter).to receive(:rate_limit).and_return(nil)
+    # Default: no claimed issues. Tests that exercise the prefix override.
+    allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index).and_return({})
+  end
 
   it "exits 2 with usage when no gem name is given" do
     expect(cli.run([])).to eq(2)
@@ -47,6 +51,19 @@ RSpec.describe GemContribute::CLI::Issues do
 
     expect(cli.run(["internal"])).to eq(1)
     expect(stderr.string).to include("only github.com is supported")
+  end
+
+  it "prefixes claimed issues with a [claimed] label" do
+    allow(adapter).to receive(:issues).and_return(
+      [issue(1234, "Fresh title"), issue(5678, "Already-being-worked-on")]
+    )
+    allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index)
+      .and_return("rubocop/rubocop" => [5678])
+
+    expect(cli.run(["rubocop"])).to eq(0)
+    out = stdout.string
+    expect(out).to match(/#1234  Fresh title/)
+    expect(out).to match(/#5678  \[claimed\] Already-being-worked-on/)
   end
 
   it "lists issues with number, title, and URL" do

--- a/spec/gem_contribute/cli/scan_spec.rb
+++ b/spec/gem_contribute/cli/scan_spec.rb
@@ -14,7 +14,37 @@ RSpec.describe GemContribute::CLI::Scan do
   # Default: every adapter mock returns nil from rate_limit so the
   # post-scan footer is a no-op. Tests that exercise the footer
   # explicitly override this.
-  before { allow(adapter).to receive(:rate_limit).and_return(nil) }
+  before do
+    allow(adapter).to receive(:rate_limit).and_return(nil)
+    # Default: no claimed issues. Tests that exercise the suffix override.
+    allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index).and_return({})
+  end
+
+  it "appends a `· N claimed` suffix when the project has claimed issues" do
+    allow(resolver).to receive(:resolve) do |gem|
+      project(gem.name) if gem.name == "rubocop"
+    end
+    allow(adapter).to receive(:issues).and_return([{ "number" => 1 }, { "number" => 2 }])
+    allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index)
+      .and_return("ruby/rubocop" => [1])
+
+    rubocop_only = File.join(fixtures, "Gemfile.rubocop_only.lock")
+    File.write(rubocop_only, <<~LOCKFILE)
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          rubocop (1.0.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        rubocop
+    LOCKFILE
+    expect(scan.run([rubocop_only])).to eq(0)
+    expect(stdout.string).to include("· 1 claimed")
+    File.delete(rubocop_only)
+  end
 
   def project(gem_name, host: "github.com", owner: "ruby", repo: nil)
     GemContribute::Project.new(

--- a/spec/gem_contribute/config_spec.rb
+++ b/spec/gem_contribute/config_spec.rb
@@ -45,6 +45,42 @@ RSpec.describe GemContribute::Config do
     end
   end
 
+  describe "#comment_on_fix?" do
+    it "defaults to true when not set" do
+      expect(config.comment_on_fix?).to be(true)
+    end
+
+    it "returns the configured boolean" do
+      File.write(path, YAML.dump("comment_on_fix" => false))
+      expect(config.comment_on_fix?).to be(false)
+    end
+
+    it "coerces a string 'false' to false" do
+      File.write(path, YAML.dump("comment_on_fix" => "false"))
+      expect(config.comment_on_fix?).to be(false)
+    end
+
+    context "with a repo argument" do
+      it "returns the global default when no override is set" do
+        expect(config.comment_on_fix?("rubocop/rubocop")).to be(true)
+      end
+
+      it "returns the per-repo override when present" do
+        File.write(path, YAML.dump("comment_on_fix" => true,
+                                   "comment_on_fix_overrides" => { "rubocop/rubocop" => false }))
+        expect(config.comment_on_fix?("rubocop/rubocop")).to be(false)
+        expect(config.comment_on_fix?("rspec/rspec")).to be(true)
+      end
+
+      it "honours the per-repo override even when the global default is off" do
+        File.write(path, YAML.dump("comment_on_fix" => false,
+                                   "comment_on_fix_overrides" => { "cdhagmann/gem-contribute" => true }))
+        expect(config.comment_on_fix?("cdhagmann/gem-contribute")).to be(true)
+        expect(config.comment_on_fix?("rspec/rspec")).to be(false)
+      end
+    end
+  end
+
   describe "#set" do
     it "writes the value and makes it readable" do
       config.set("clone_root", "~/code/gems")

--- a/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
+++ b/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
@@ -191,6 +191,36 @@ RSpec.describe GemContribute::HostAdapters::GitHubAdapter do
     end
   end
 
+  describe "#search_issues" do
+    it "GETs /search/issues with the q param and returns the items array" do
+      stub_request(:get, "https://api.github.com/search/issues")
+        .with(query: { "q" => "\"<!-- gem-contribute:working v1 -->\"" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.dump("total_count" => 1,
+                          "items" => [{ "number" => 7,
+                                        "html_url" => "https://github.com/sidekiq/sidekiq/issues/7" }])
+        )
+
+      items = adapter.search_issues("\"<!-- gem-contribute:working v1 -->\"")
+      expect(items.size).to eq(1)
+      expect(items.first["number"]).to eq(7)
+    end
+
+    it "caches the result by query so repeat calls don't re-hit the API" do
+      stub_request(:get, "https://api.github.com/search/issues")
+        .with(query: { "q" => "anything" })
+        .to_return(status: 200,
+                   headers: { "Content-Type" => "application/json" },
+                   body: JSON.dump("items" => []))
+
+      adapter.search_issues("anything")
+      adapter.search_issues("anything")
+      expect(WebMock).to have_requested(:get, %r{api\.github\.com/search/issues}).once
+    end
+  end
+
   describe "non-200 from a public endpoint" do
     it "raises AdapterError with the status" do
       stub_request(:get, %r{api\.github\.com/repos/sidekiq/sidekiq/issues})

--- a/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
+++ b/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
@@ -79,6 +79,18 @@ RSpec.describe GemContribute::HostAdapters::GitHubAdapter do
     end
   end
 
+  describe "#comment_on_issue without a token" do
+    it "raises AuthRequired" do
+      expect { adapter.comment_on_issue(project, 1, "x") }.to raise_error(GemContribute::AuthRequired)
+    end
+  end
+
+  describe "#issue_comments without a token" do
+    it "raises AuthRequired" do
+      expect { adapter.issue_comments(project, 1) }.to raise_error(GemContribute::AuthRequired)
+    end
+  end
+
   context "with a token" do
     let(:adapter) { described_class.new(cache: cache, token: "gho_test") }
 
@@ -141,6 +153,40 @@ RSpec.describe GemContribute::HostAdapters::GitHubAdapter do
       it "returns false on 404 (still propagating)" do
         stub_request(:get, "https://api.github.com/repos/alice/sidekiq").to_return(status: 404)
         expect(adapter.fork_ready?("alice", "sidekiq")).to be(false)
+      end
+    end
+
+    describe "#comment_on_issue" do
+      it "POSTs to /repos/:owner/:repo/issues/:n/comments and returns the parsed body" do
+        stub_request(:post, "https://api.github.com/repos/sidekiq/sidekiq/issues/1234/comments")
+          .with(headers: { "Authorization" => "Bearer gho_test" },
+                body: hash_including("body" => "Hello world"))
+          .to_return(
+            status: 201,
+            headers: { "Content-Type" => "application/json" },
+            body: JSON.dump("id" => 999, "body" => "Hello world",
+                            "html_url" => "https://github.com/sidekiq/sidekiq/issues/1234#issuecomment-999")
+          )
+
+        body = adapter.comment_on_issue(project, 1234, "Hello world")
+        expect(body["id"]).to eq(999)
+        expect(body["body"]).to eq("Hello world")
+      end
+    end
+
+    describe "#issue_comments" do
+      it "GETs the issue comments and returns the parsed array" do
+        stub_request(:get, "https://api.github.com/repos/sidekiq/sidekiq/issues/1234/comments")
+          .with(headers: { "Authorization" => "Bearer gho_test" })
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: JSON.dump([{ "id" => 1, "body" => "first" }, { "id" => 2, "body" => "second" }])
+          )
+
+        comments = adapter.issue_comments(project, 1234)
+        expect(comments.size).to eq(2)
+        expect(comments.first["body"]).to eq("first")
       end
     end
   end


### PR DESCRIPTION
## Summary

Two halves of one feature, both threaded through a shared `<!-- gem-contribute:working v1 -->` marker:

**Write half** (`fix`) — after a successful clone, post a "working on this" comment to the issue. Default-on, with `--no-comment` per-invocation, a global `comment_on_fix` config, and per-repo `comment_on_fix_overrides` for maintainers who don't want it. Soft-fails — fork/clone/branch still succeeds even if the API rejects the comment.

**Read half** (`scan` / `issues`) — surface claimed issues at discovery time so contributors don't double up:
- `scan` appends `· N claimed` to project lines with claimed issues.
- `issues <gem>` and `issues all` inline `[claimed]` before the title.

Closes #18, closes #20.

## Review preference

- [ ] **Ship it.** Review for correctness, tests, and design fit. Skip style nits unless they're load-bearing.
- [x] **Full review, please.** Feedback on style, naming, idioms, and alternative designs welcome.

## Working agreement check

- [x] Single concern (the claim feature loop — write the marker, read the marker, with the small refactors each requires).
- [x] ADRs touched: none. UX/feature change.
- [x] `bin/rubocop` and `bin/rspec` pass for the files this PR touches (186 examples, 0 failures; 6 pre-existing `RSpec/ReceiveMessages` style nits in scan/issues specs are unaddressed per single-concern).
- [x] New behavior tested at every layer — adapter (`search_issues`, `comment_on_issue`, `issue_comments`), `IssueAnnouncer` (announce + fetch_claim_index), `Fix` (skip ladder branches), `Scan` and `Issues` (suffix/prefix render).
- [x] Async work goes through Rooibos Commands — N/A.

## Skip ladder (write half)

The comment posts only when **none** of these short-circuit (cheapest first):

1. `--no-comment` flag passed.
2. **The branch `gem-contribute/issue-<N>` already exists locally** (the user is resuming *this* issue specifically — the clone is shared across issues, the branch is per-issue).
3. `viewer.login == project.owner` — don't announce on your own issue. Same detection [#10](https://github.com/cdhagmann/gem-contribute/issues/10) is about; duplicated inline now, unify when #10 lands.
4. Per-repo config opts out (`comment_on_fix_overrides[<owner/repo>]`).
5. Global `comment_on_fix` is false.
6. Marker found in viewer's prior comments — already announced.

## Read half — claim discovery

`IssueAnnouncer.fetch_claim_index(adapter)` searches GitHub for the marker and returns a `{ "owner/repo" => [numbers] }` index. One search call per invocation, cached under the `issues` namespace; degrades to an empty index on any AdapterError so the feature stays additive (zero impact on anonymous scans, hits the broader 60/hr limit only when network and auth permit).

`Scan` and `Issues` consume the index without knowing how it's built. Same module owns marker semantics for both write and read, so future `gem-contribute abandon` plugs in with a different verb (`<!-- gem-contribute:abandon v1 -->`) without touching this code.

## Notes for reviewer

- **`Fix#initialize` is now 10 kwargs** (added `config:`). Existing `# rubocop:disable Metrics/ParameterLists` covers it. `Fix` ClassLength also disabled with rationale comment.
- **`GitHubAdapter` ClassLength** disabled inline — the adapter wraps a growing endpoint surface (issues, comments, search, forks, contents), and the metric isn't a useful constraint there.
- **Soft-fail messages** let `fix` exit 0 on the write side, and the read side silently degrades to no-flags on any AdapterError.
- **`config list` surfaces the new keys** including the per-repo overrides hash when set.
- **Per-repo override values are YAML-only** (the hash isn't in `KNOWN_KEYS` so `config set` won't touch it). User edits `~/.config/gem-contribute/config.yml` directly to add overrides.
- **Pre-existing rubocop offenses** in `spec/gem_contribute/cli/issues_spec.rb` and `scan_spec.rb` (`RSpec/ReceiveMessages` — combine adjacent `allow().to receive` calls) are unaddressed per single-concern. Happy to file as a separate cleanup.

## Out of scope (kept the corner unpainted)

- `gem-contribute abandon <gem>/<issue#>` — same plumbing, different verb. `IssueAnnouncer` already designed for it.
- `--comment` to *force* a post on resume.
- Custom comment bodies via config (`fix_comment_body`).
- A `gem-contribute config set comment_on_fix_overrides.<repo> <bool>` subkey syntax.
- Stale-claim detection (a 6-month-old marker probably means the contributor abandoned).
- Self-vs-others differentiation in claim flags.

## Commits

1. `762de21` — feat(fix): post the comment + skip ladder + IssueAnnouncer extraction
2. `d5646ee` — fix: scope skip-on-resume to the issue's branch, not the clone (per feedback)
3. `c21f391` — feat(scan, issues): flag claimed issues using the marker