### PR TITLE
Phase 1: ADR-0012 service layer (#25, #26, #27, #28)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,9 @@ PATH
   specs:
     gem-contribute (0.2.0)
       bundler (>= 2.4)
+      dry-initializer (~> 3.2)
+      dry-monads (~> 1.10)
+      dry-operation (~> 1.1)
       zeitwerk (~> 2.6)
 
 GEM
@@ -12,11 +15,24 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
     crack (1.0.1)
       bigdecimal
       rexml
     date (3.5.1)
     diff-lcs (1.6.2)
+    dry-core (1.2.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-initializer (3.2.0)
+    dry-monads (1.10.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-operation (1.1.0)
+      dry-monads (~> 1.6)
+      zeitwerk (~> 2.6)
     erb (6.0.4)
     hashdiff (1.2.1)
     io-console (0.8.2)
@@ -28,6 +44,7 @@ GEM
     json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -117,9 +134,14 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  dry-core (1.2.0) sha256=0cc5a7da88df397f153947eeeae42e876e999c1e30900f3c536fb173854e96a1
+  dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3
+  dry-monads (1.10.0) sha256=68c90d77617c6ce88d60704fc3b233907e6320974152fe75ad947f968006ca39
+  dry-operation (1.1.0) sha256=db4227ac0c9313c0c84eda4e26539dcc1e1aae9effdf9e60a397ab2a90a01b92
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   gem-contribute (0.2.0)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
@@ -128,6 +150,7 @@ CHECKSUMS
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6

--- a/gem-contribute.gemspec
+++ b/gem-contribute.gemspec
@@ -41,5 +41,8 @@ Gem::Specification.new do |spec|
   # Bundler ships with Ruby; declared explicitly because we use its lockfile parser.
   # See ADR-0002.
   spec.add_dependency "bundler", ">= 2.4"
+  spec.add_dependency "dry-initializer", "~> 3.2"
+  spec.add_dependency "dry-monads", "~> 1.10"
+  spec.add_dependency "dry-operation", "~> 1.1"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/gem_contribute/cli.rb
+++ b/lib/gem_contribute/cli.rb
@@ -63,7 +63,7 @@ module GemContribute
       "config" => ->(o, e) { Config.new(stdout: o, stderr: e) },
       "auth" => ->(o, e) { Auth.new(stdout: o, stderr: e) },
       "fork" => ->(o, e) { Fork.new(stdout: o, stderr: e, clone_root: GemContribute::Config.new.clone_root) },
-      "fix" => ->(o, e) {
+      "fix" => lambda { |o, e|
         config = GemContribute::Config.new
         Fix.new(stdout: o, stderr: e, clone_root: config.clone_root, config: config)
       },

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -46,20 +46,22 @@ module GemContribute
       # rubocop:enable Metrics/ParameterLists
 
       def run(argv)
-        with_workflow_rescues("fix") do
-          return missing_clone_root if @clone_root.nil?
+        return missing_clone_root if @clone_root.nil?
 
-          target, flags = parse_argv(argv)
-          return print_usage_error if target.nil? || !target.include?("/")
+        target, flags = parse_argv(argv)
+        return print_usage_error if target.nil? || !target.include?("/")
 
-          gem_name, issue = target.split("/", 2)
-          adapter = build_adapter
-          return 1 if adapter.nil?
+        gem_name, issue = target.split("/", 2)
 
+        case build_adapter
+        in Success(adapter)
           project = resolve_target(gem_name, verb: "fix")
           return 1 if project.nil?
 
           execute(adapter, project, issue, flags)
+        in Failure(:unauthenticated)
+          @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
+          1
         end
       end
 
@@ -97,6 +99,12 @@ module GemContribute
           @stderr.puts "fix failed: #{message}"
           1
         end
+      rescue GemContribute::AdapterError => e
+        # Catches AdapterError from non-Operation paths still in this verb
+        # (currently @git.checkout_branch in finish_fix). #27 will fold the
+        # branch step into Operations::Branch and remove the need for this.
+        @stderr.puts "fix failed: #{e.message}"
+        1
       end
 
       def finish_fix(adapter, project, issue, flags, local_path, fork_info, was_resuming:)

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/monads"
+
 module GemContribute
   module CLI
     # `gem-contribute fix <gem>/<issue#> [-e] [-a] [--no-comment]`
@@ -10,6 +12,7 @@ module GemContribute
     # comment (skippable), optionally open the user's editor or AI tool.
     class Fix
       include Workflow
+      include Dry::Monads[:result]
 
       DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
       BRANCH_PREFIX = "gem-contribute/issue-"
@@ -83,7 +86,20 @@ module GemContribute
 
       def execute(adapter, project, issue, flags)
         was_resuming = branch_exists_locally?(project, issue)
-        local_path, fork_info = @fork.bootstrap(adapter, project)
+
+        case @fork.bootstrap(adapter, project)
+        in Success(local_path, fork_info)
+          finish_fix(adapter, project, issue, flags, local_path, fork_info, was_resuming: was_resuming)
+        in Failure(:unauthenticated)
+          @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
+          1
+        in Failure(:adapter_error, message)
+          @stderr.puts "fix failed: #{message}"
+          1
+        end
+      end
+
+      def finish_fix(adapter, project, issue, flags, local_path, fork_info, was_resuming:)
         branch_name = "#{BRANCH_PREFIX}#{issue}"
         @git.checkout_branch(local_path, branch_name)
 

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/initializer"
 require "dry/monads"
 
 module GemContribute
@@ -11,33 +12,23 @@ module GemContribute
     # tool. The verb is a thin Result-pattern-matching shell around the
     # pipeline (per ADR-0012).
     class Fix
+      extend Dry::Initializer
       include Workflow
       include Dry::Monads[:result]
 
       DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
 
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(stdout: $stdout,
-                     stderr: $stderr,
-                     resolver: Resolver.new,
-                     store: TokenStore.new,
-                     adapter_factory: ->(token:) { HostAdapters::GitHubAdapter.new(token: token) },
-                     git: GemContribute::Git.new,
-                     clone_root: DEFAULT_CLONE_ROOT,
-                     post_clone_hooks: nil,
-                     config: nil,
-                     pipeline: nil)
-        @stdout = stdout
-        @stderr = stderr
-        @resolver = resolver
-        @store = store
-        @adapter_factory = adapter_factory
-        @clone_root = clone_root
-        @post_clone_hooks = post_clone_hooks || PostCloneHooks.new(stdout: stdout, stderr: stderr)
-        @config = config || GemContribute::Config.new
-        @pipeline = pipeline || Operations::FixPipeline.new(git: git)
-      end
-      # rubocop:enable Metrics/ParameterLists
+      option :stdout, default: -> { $stdout }
+      option :stderr, default: -> { $stderr }
+      option :resolver, default: -> { Resolver.new }
+      option :store, default: -> { TokenStore.new }
+      option :adapter_factory,
+             default: -> { ->(token:) { HostAdapters::GitHubAdapter.new(token: token) } }
+      option :git, default: -> { GemContribute::Git.new }
+      option :clone_root, default: -> { DEFAULT_CLONE_ROOT }
+      option :post_clone_hooks, default: -> { PostCloneHooks.new(stdout: stdout, stderr: stderr) }
+      option :config, default: -> { GemContribute::Config.new }
+      option :pipeline, default: -> { Operations::FixPipeline.new(git: git) }
 
       def run(argv)
         return missing_clone_root if @clone_root.nil?

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -6,16 +6,15 @@ module GemContribute
   module CLI
     # `gem-contribute fix <gem>/<issue#> [-e] [-a] [--no-comment]`
     #
-    # The issue-tied path: bootstrap a fork+clone (delegated to `CLI::Fork`'s
-    # primitive, which composes `Operations::Fork` and `Operations::Clone`),
-    # then branch to `gem-contribute/issue-<N>`, post a "working on this"
-    # comment (skippable), optionally open the user's editor or AI tool.
+    # The issue-tied path: run `Operations::FixPipeline` (Fork → Clone →
+    # Branch → Announce), then optionally open the user's editor or AI
+    # tool. The verb is a thin Result-pattern-matching shell around the
+    # pipeline (per ADR-0012).
     class Fix
       include Workflow
       include Dry::Monads[:result]
 
       DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
-      BRANCH_PREFIX = "gem-contribute/issue-"
 
       # rubocop:disable Metrics/ParameterLists
       def initialize(stdout: $stdout,
@@ -27,21 +26,16 @@ module GemContribute
                      clone_root: DEFAULT_CLONE_ROOT,
                      post_clone_hooks: nil,
                      config: nil,
-                     fork: nil)
+                     pipeline: nil)
         @stdout = stdout
         @stderr = stderr
         @resolver = resolver
         @store = store
         @adapter_factory = adapter_factory
-        @git = git
         @clone_root = clone_root
         @post_clone_hooks = post_clone_hooks || PostCloneHooks.new(stdout: stdout, stderr: stderr)
         @config = config || GemContribute::Config.new
-        @fork = fork || Fork.new(stdout: stdout, stderr: stderr,
-                                 resolver: resolver, store: store,
-                                 adapter_factory: adapter_factory,
-                                 git: @git, clone_root: clone_root,
-                                 post_clone_hooks: @post_clone_hooks)
+        @pipeline = pipeline || Operations::FixPipeline.new(git: git)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -87,11 +81,18 @@ module GemContribute
       end
 
       def execute(adapter, project, issue, flags)
-        was_resuming = branch_exists_locally?(project, issue)
+        allow_announce = !flags[:no_comment] &&
+                         @config.comment_on_fix?("#{project.owner}/#{project.repo}")
 
-        case @fork.bootstrap(adapter, project)
-        in Success(local_path, fork_info)
-          finish_fix(adapter, project, issue, flags, local_path, fork_info, was_resuming: was_resuming)
+        @stdout.puts "Forking #{project.owner}/#{project.repo}..."
+
+        case @pipeline.call(adapter: adapter, project: project, issue: issue,
+                            root: @clone_root, allow_announce: allow_announce)
+        in Success(fork: fork_data, clone: clone_data, branch: branch_data, announce: announce_data)
+          print_summary(clone_data.path, branch_data.name, fork_data)
+          print_announce_outcome(announce_data, issue)
+          @post_clone_hooks.call(clone_data.path, editor: flags[:editor], ai_tool: flags[:ai_tool])
+          0
         in Failure(:unauthenticated)
           @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
           1
@@ -99,23 +100,6 @@ module GemContribute
           @stderr.puts "fix failed: #{message}"
           1
         end
-      rescue GemContribute::AdapterError => e
-        # Catches AdapterError from non-Operation paths still in this verb
-        # (currently @git.checkout_branch in finish_fix). #27 will fold the
-        # branch step into Operations::Branch and remove the need for this.
-        @stderr.puts "fix failed: #{e.message}"
-        1
-      end
-
-      def finish_fix(adapter, project, issue, flags, local_path, fork_info, was_resuming:)
-        branch_name = "#{BRANCH_PREFIX}#{issue}"
-        @git.checkout_branch(local_path, branch_name)
-
-        print_summary(local_path, branch_name, fork_info)
-        announce_or_skip(adapter, project, issue, fork_info.viewer,
-                         was_resuming: was_resuming, flags: flags)
-        @post_clone_hooks.call(local_path, editor: flags[:editor], ai_tool: flags[:ai_tool])
-        0
       end
 
       def print_summary(local_path, branch_name, fork_info)
@@ -128,30 +112,16 @@ module GemContribute
         @stdout.puts "Next: cd #{local_path} && make your changes, then `gem-contribute submit`."
       end
 
-      # True if `gem-contribute/issue-<N>` already exists locally — the
-      # user is resuming this specific issue (the clone is shared across
-      # issues in the same repo, but the branch is per-issue).
-      def branch_exists_locally?(project, issue)
-        target = File.join(@clone_root, project.owner, project.repo)
-        return false unless File.directory?(File.join(target, ".git"))
-
-        @git.branch_exists?(target, "#{BRANCH_PREFIX}#{issue}")
-      end
-
-      def announce_or_skip(adapter, project, issue, viewer, was_resuming:, flags:)
-        return unless should_announce?(project, viewer, was_resuming: was_resuming, flags: flags)
-
-        IssueAnnouncer.announce_working(
-          adapter: adapter, project: project, issue: issue,
-          stdout: @stdout, stderr: @stderr
-        )
-      end
-
-      def should_announce?(project, viewer, was_resuming:, flags:)
-        !flags[:no_comment] &&
-          !was_resuming &&
-          viewer != project.owner &&
-          @config.comment_on_fix?("#{project.owner}/#{project.repo}")
+      def print_announce_outcome(announce_result, issue)
+        case announce_result
+        in Success(:posted)
+          @stdout.puts "Posted 'working on this' comment to issue ##{issue}."
+        in Success(:skipped)
+          # no output for skipped — quiet success
+        in Failure(:announce_failed, message)
+          @stderr.puts "Note: couldn't post 'working on this' comment to issue ##{issue}: " \
+                       "#{message}. Continuing."
+        end
       end
     end
   end

--- a/lib/gem_contribute/cli/fork.rb
+++ b/lib/gem_contribute/cli/fork.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/initializer"
 require "dry/monads"
 
 module GemContribute
@@ -11,30 +12,23 @@ module GemContribute
     # filesystem policy lives in Operations (ADR-0011). Operations are
     # output-free per ADR-0012; this verb does the printing.
     class Fork
+      extend Dry::Initializer
       include Workflow
       include Dry::Monads[:result]
 
       DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
 
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(stdout: $stdout, stderr: $stderr,
-                     resolver: Resolver.new, store: TokenStore.new,
-                     adapter_factory: ->(token:) { HostAdapters::GitHubAdapter.new(token: token) },
-                     git: GemContribute::Git.new,
-                     clone_root: DEFAULT_CLONE_ROOT,
-                     post_clone_hooks: nil,
-                     fork_op: nil, clone_op: nil)
-        @stdout = stdout
-        @stderr = stderr
-        @resolver = resolver
-        @store = store
-        @adapter_factory = adapter_factory
-        @clone_root = clone_root
-        @post_clone_hooks = post_clone_hooks || PostCloneHooks.new(stdout: stdout, stderr: stderr)
-        @fork_op = fork_op || Operations::Fork.new
-        @clone_op = clone_op || Operations::Clone.new(git: git)
-      end
-      # rubocop:enable Metrics/ParameterLists
+      option :stdout, default: -> { $stdout }
+      option :stderr, default: -> { $stderr }
+      option :resolver, default: -> { Resolver.new }
+      option :store, default: -> { TokenStore.new }
+      option :adapter_factory,
+             default: -> { ->(token:) { HostAdapters::GitHubAdapter.new(token: token) } }
+      option :git, default: -> { GemContribute::Git.new }
+      option :clone_root, default: -> { DEFAULT_CLONE_ROOT }
+      option :post_clone_hooks, default: -> { PostCloneHooks.new(stdout: stdout, stderr: stderr) }
+      option :fork_op, default: -> { Operations::Fork.new }
+      option :clone_op, default: -> { Operations::Clone.new(git: git) }
 
       def run(argv)
         return missing_clone_root if @clone_root.nil?

--- a/lib/gem_contribute/cli/fork.rb
+++ b/lib/gem_contribute/cli/fork.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
+require "dry/monads"
+
 module GemContribute
   module CLI
     # `gem-contribute fork <gem|owner/repo> [-e] [-a]`. Resolve the target,
     # bootstrap a fork+clone via `Operations::Fork` + `Operations::Clone`,
     # print a summary, run post-clone hooks. The CLI verb is a thin
     # composition; the host-API ceremony lives in the adapter and the
-    # filesystem policy lives in Operations (ADR-0011).
+    # filesystem policy lives in Operations (ADR-0011). Operations are
+    # output-free per ADR-0012; this verb does the printing.
     class Fork
       include Workflow
+      include Dry::Monads[:result]
 
       DEFAULT_CLONE_ROOT = File.expand_path("~/code/oss")
 
@@ -27,8 +31,8 @@ module GemContribute
         @adapter_factory = adapter_factory
         @clone_root = clone_root
         @post_clone_hooks = post_clone_hooks || PostCloneHooks.new(stdout: stdout, stderr: stderr)
-        @fork_op = fork_op || Operations::Fork.new(stdout: stdout)
-        @clone_op = clone_op || Operations::Clone.new(git: git, stdout: stdout)
+        @fork_op = fork_op || Operations::Fork.new
+        @clone_op = clone_op || Operations::Clone.new(git: git)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -50,13 +54,25 @@ module GemContribute
       end
 
       # The bootstrap primitive Fix shares: fork (or reuse) → clone (or
-      # reuse) → upstream remote. Returns `[local_path, fork_info]` where
-      # `fork_info` is an `Operations::Fork::Result`.
+      # reuse) → upstream remote. Returns `Success([local_path, fork_info])`
+      # on the happy path; `Failure(reason)` propagated from Operations
+      # otherwise.
       def bootstrap(adapter, project)
-        fork_info = @fork_op.call(adapter: adapter, project: project)
-        local_path = @clone_op.call(adapter: adapter, project: project,
-                                    fork_clone_url: fork_info.clone_url, root: @clone_root)
-        [local_path, fork_info]
+        @stdout.puts "Forking #{project.owner}/#{project.repo}..."
+        fork_result = @fork_op.call(adapter: adapter, project: project)
+        return fork_result if fork_result.failure?
+
+        fork_info = fork_result.value!
+        @stdout.puts fork_status_line(fork_info, project)
+
+        clone_result = @clone_op.call(adapter: adapter, project: project,
+                                      fork_clone_url: fork_info.clone_url, root: @clone_root)
+        return clone_result if clone_result.failure?
+
+        clone_info = clone_result.value!
+        @stdout.puts clone_status_line(clone_info)
+
+        Success([clone_info.path, fork_info])
       end
 
       private
@@ -80,11 +96,34 @@ module GemContribute
       end
 
       def execute(adapter, project, flags)
-        local_path, fork_info = bootstrap(adapter, project)
+        case bootstrap(adapter, project)
+        in Success(local_path, fork_info)
+          print_summary(local_path, project, fork_info)
+          @post_clone_hooks.call(local_path, editor: flags[:editor], ai_tool: flags[:ai_tool])
+          0
+        in Failure(:unauthenticated)
+          @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
+          1
+        in Failure(:adapter_error, message)
+          @stderr.puts "fork failed: #{message}"
+          1
+        end
+      end
 
-        print_summary(local_path, project, fork_info)
-        @post_clone_hooks.call(local_path, editor: flags[:editor], ai_tool: flags[:ai_tool])
-        0
+      def fork_status_line(info, project)
+        if info.reused
+          "  Reusing existing fork at #{info.viewer}/#{project.repo}."
+        else
+          "  Forked → #{info.viewer}/#{project.repo}."
+        end
+      end
+
+      def clone_status_line(info)
+        if info.reused
+          "Reusing existing clone at #{info.path}."
+        else
+          "Cloned into #{info.path}."
+        end
       end
 
       def print_summary(local_path, project, fork_info)

--- a/lib/gem_contribute/cli/fork.rb
+++ b/lib/gem_contribute/cli/fork.rb
@@ -37,19 +37,20 @@ module GemContribute
       # rubocop:enable Metrics/ParameterLists
 
       def run(argv)
-        with_workflow_rescues("fork") do
-          return missing_clone_root if @clone_root.nil?
+        return missing_clone_root if @clone_root.nil?
 
-          target, flags = parse_argv(argv)
-          return print_usage_error if target.nil?
+        target, flags = parse_argv(argv)
+        return print_usage_error if target.nil?
 
-          adapter = build_adapter
-          return 1 if adapter.nil?
-
+        case build_adapter
+        in Success(adapter)
           project = resolve_target(target, verb: "fork", allow_owner_repo: true)
           return 1 if project.nil?
 
           execute(adapter, project, flags)
+        in Failure(:unauthenticated)
+          @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
+          1
         end
       end
 

--- a/lib/gem_contribute/cli/issue_announcer.rb
+++ b/lib/gem_contribute/cli/issue_announcer.rb
@@ -2,49 +2,16 @@
 
 module GemContribute
   module CLI
-    # Body templates and marker matching for issue announcements posted by
-    # `gem-contribute fix` (and future `abandon`). The marker is an HTML
-    # comment in the body so re-runs can detect prior posts deterministically.
+    # CLI-side helpers for the "I'm working on this" claim machinery.
     #
-    # Format: `<!-- gem-contribute:<verb> v<n> -->`. The verb is namespaced so
-    # multiple announcement types can coexist on one issue (a `working` and
-    # later an `abandon` describe different states). The version suffix lets
-    # us rev the body without invalidating the matcher.
+    # The actual posting (and gating) lives in `Operations::Announce`
+    # (output-free, Result-returning) — see ADR-0012. What remains here
+    # is the index-fetching used by `scan` and `issues` to flag claimed
+    # issues in their output. Both halves share `Operations::Announce::WORKING_MARKER`.
     module IssueAnnouncer
-      WORKING_MARKER = "<!-- gem-contribute:working v1 -->"
-      WORKING_BODY = <<~BODY.freeze
-        #{WORKING_MARKER}
-        👋 I've started working on this. I'll open a PR shortly.
-
-        <sub>Posted via [gem-contribute](https://github.com/cdhagmann/gem-contribute).</sub>
-      BODY
+      MARKER = Operations::Announce::WORKING_MARKER
 
       module_function
-
-      # Returns:
-      #   :posted  — comment was posted
-      #   :skipped — viewer's prior comments contain the marker (already announced)
-      #   :failed  — API call raised; warning printed to stderr
-      def announce_working(adapter:, project:, issue:, stdout:, stderr:)
-        return :skipped if already_announced?(adapter, project, issue, WORKING_MARKER)
-
-        adapter.comment(project, issue: issue, body: WORKING_BODY)
-        stdout.puts "Posted 'working on this' comment to issue ##{issue}."
-        :posted
-      rescue GemContribute::AdapterError => e
-        stderr.puts "Note: couldn't post 'working on this' comment to issue ##{issue}: " \
-                    "#{e.message}. Continuing."
-        :failed
-      end
-
-      def already_announced?(adapter, project, issue, marker)
-        comments = adapter.issue_comments(project, issue)
-        comments.any? { |c| c["body"].to_s.include?(marker) }
-      rescue GemContribute::AdapterError
-        # If we can't fetch comments, assume not announced and let the post
-        # attempt fail safely on its own.
-        false
-      end
 
       # Builds a lookup hash of {"owner/repo" => Set<issue_number>} from
       # GitHub's issue search for our marker. Used by `scan` and `issues`
@@ -52,7 +19,7 @@ module GemContribute
       # caches the result for the issues TTL). Degrades to an empty hash
       # if the search fails (anonymous rate limits, network, etc.).
       def fetch_claim_index(adapter)
-        items = adapter.search_issues("\"#{WORKING_MARKER}\"")
+        items = adapter.search_issues("\"#{MARKER}\" is:issue is:open")
         items.each_with_object(Hash.new { |h, k| h[k] = [] }) do |item, index|
           parsed = parse_issue_url(item["html_url"])
           next unless parsed

--- a/lib/gem_contribute/cli/submit.rb
+++ b/lib/gem_contribute/cli/submit.rb
@@ -146,7 +146,6 @@ module GemContribute
         @stdout.puts opened ? "Opened browser to:" : "Open this URL to file the PR:"
         @stdout.puts "  #{url}"
       end
-
     end
   end
 end

--- a/lib/gem_contribute/cli/workflow.rb
+++ b/lib/gem_contribute/cli/workflow.rb
@@ -1,44 +1,34 @@
 # frozen_string_literal: true
 
+require "dry/monads"
+
 module GemContribute
   module CLI
     # Shared scaffolding for action-style CLI verbs (Fix, Fork, future
-    # Abandon). Each verb still owns its own `parse_argv`, `execute`, and
+    # Abandon). Each verb owns its own `parse_argv`, `execute`, and
     # `print_usage_error`; this module captures the common pieces around
-    # them: the missing-clone_root error, the auth-token check, the
-    # project resolver, and the AdapterError/AuthRequired rescue shell.
+    # them: the missing-clone_root error, the auth-token check (as a
+    # Result-returning service per ADR-0012), and the project resolver.
     #
     # Including classes are expected to hold:
     #   @stderr, @resolver, @store, @adapter_factory, @clone_root
     module Workflow
-      private
+      include Dry::Monads[:result]
 
-      # Wraps the verb's run body. `return` inside the block exits the
-      # enclosing run method (Ruby's non-local return); raised
-      # AuthRequired/AdapterError land here and produce a 1 exit status
-      # with a friendly message.
-      def with_workflow_rescues(verb)
-        yield
-      rescue GemContribute::AuthRequired
-        @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
-        1
-      rescue GemContribute::AdapterError => e
-        @stderr.puts "#{verb} failed: #{e.message}"
-        1
-      end
+      private
 
       def missing_clone_root
         @stderr.puts "clone_root is not configured. Run `gem-contribute init` first."
         1
       end
 
+      # Per ADR-0012: returns Success(adapter) | Failure(:unauthenticated).
+      # Callers pattern-match — no nil + stderr side effect, no exceptions.
       def build_adapter
         token = @store.token_for("github.com")
-        if token.nil?
-          @stderr.puts "Not authenticated. Run `gem-contribute auth login` first."
-          return nil
-        end
-        @adapter_factory.call(token: token)
+        return Failure(:unauthenticated) if token.nil?
+
+        Success(@adapter_factory.call(token: token))
       end
 
       # Resolves a CLI target to a `github.com` Project, or prints an

--- a/lib/gem_contribute/operations/announce.rb
+++ b/lib/gem_contribute/operations/announce.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+module GemContribute
+  module Operations
+    # Bootstrap step 4: post (or skip) a "working on this" comment on the
+    # upstream issue. The marker is an HTML comment in the body so re-runs
+    # detect prior posts deterministically.
+    #
+    # Format: `<!-- gem-contribute:<verb> v<n> -->`. Output-free per
+    # ADR-0012; callers render the outcome.
+    #
+    # Returns:
+    #   Success(:posted)  — comment was posted
+    #   Success(:skipped) — gating said no, OR the marker was already present
+    #   Failure([:announce_failed, message]) — adapter raised; the caller
+    #     usually treats this as a non-fatal warning rather than a fix failure
+    class Announce
+      include Dry::Monads[:result]
+
+      WORKING_MARKER = "<!-- gem-contribute:working v1 -->"
+      WORKING_BODY = <<~BODY.freeze
+        #{WORKING_MARKER}
+        👋 I've started working on this. I'll open a PR shortly.
+
+        <sub>Posted via [gem-contribute](https://github.com/cdhagmann/gem-contribute).</sub>
+      BODY
+
+      def call(adapter:, project:, issue:, allow:)
+        return Success(:skipped) unless allow
+        return Success(:skipped) if already_announced?(adapter, project, issue)
+
+        adapter.comment(project, issue: issue, body: WORKING_BODY)
+        Success(:posted)
+      rescue GemContribute::AdapterError => e
+        Failure([:announce_failed, e.message])
+      end
+
+      private
+
+      def already_announced?(adapter, project, issue)
+        comments = adapter.issue_comments(project, issue)
+        comments.any? { |c| c["body"].to_s.include?(WORKING_MARKER) }
+      rescue GemContribute::AdapterError
+        # If we can't fetch comments, assume not announced and let the
+        # post attempt fail safely on its own.
+        false
+      end
+    end
+  end
+end

--- a/lib/gem_contribute/operations/branch.rb
+++ b/lib/gem_contribute/operations/branch.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+module GemContribute
+  module Operations
+    # Bootstrap step 3: create the per-issue working branch in the fork
+    # clone. The branch name is `gem-contribute/issue-<N>`. Output-free
+    # per ADR-0012.
+    #
+    # Note: `git checkout -b` fails if the branch already exists, which
+    # surfaces as `Failure([:adapter_error, ...])` here. That preserves
+    # the pre-extraction behaviour where re-running `fix` on an issue
+    # whose branch already exists locally errored out — see [#10] for
+    # the friendlier-message follow-up.
+    class Branch
+      include Dry::Monads[:result]
+
+      Result = Data.define(:name)
+      PREFIX = "gem-contribute/issue-"
+
+      def initialize(git: Git.new)
+        @git = git
+      end
+
+      def call(path:, issue:)
+        name = "#{PREFIX}#{issue}"
+        @git.checkout_branch(path, name)
+        Success(Result.new(name: name))
+      rescue GemContribute::AdapterError => e
+        Failure([:adapter_error, e.message])
+      end
+    end
+  end
+end

--- a/lib/gem_contribute/operations/clone.rb
+++ b/lib/gem_contribute/operations/clone.rb
@@ -1,35 +1,40 @@
 # frozen_string_literal: true
 
+require "dry/monads"
 require "fileutils"
 
 module GemContribute
   module Operations
     # Bootstrap step 2: clone the fork into `<root>/<owner>/<repo>` (reusing
     # an existing clone if one is there), and ensure an `upstream` remote
-    # points at the canonical project. Returns the local clone path.
+    # points at the canonical project. Returns a `Result` carrying the
+    # local path and a `reused` flag, or a tagged `Failure`.
     #
     # The "reuse if `.git` exists" rule and the upstream-remote convention
     # are gem-contribute policy on top of git, not git itself — that's why
     # they live here rather than in `Git`.
     class Clone
-      def initialize(git: Git.new, stdout: $stdout)
+      include Dry::Monads[:result]
+
+      Result = Data.define(:path, :reused)
+
+      def initialize(git: Git.new)
         @git = git
-        @stdout = stdout
       end
 
       def call(adapter:, project:, fork_clone_url:, root:)
         target = File.join(root, project.owner, project.repo)
+        reused = File.directory?(File.join(target, ".git"))
 
-        if File.directory?(File.join(target, ".git"))
-          @stdout.puts "Reusing existing clone at #{target}."
-        else
+        unless reused
           FileUtils.mkdir_p(File.dirname(target))
-          @stdout.puts "Cloning into #{target}..."
           @git.clone(fork_clone_url, target)
         end
 
         @git.add_remote(target, "upstream", adapter.clone_url(project.owner, project.repo))
-        target
+        Success(Result.new(path: target, reused: reused))
+      rescue GemContribute::AdapterError => e
+        Failure([:adapter_error, e.message])
       end
     end
   end

--- a/lib/gem_contribute/operations/fix_pipeline.rb
+++ b/lib/gem_contribute/operations/fix_pipeline.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "dry/operation"
+require "dry/monads"
+
+module GemContribute
+  module Operations
+    # Composes the four `fix` steps — Fork → Clone → Branch → Announce —
+    # using `dry-operation`. Each `step` short-circuits on Failure;
+    # Announce is called outside `step` because its Failure is
+    # informational (the fix has already happened) and should not
+    # propagate as a pipeline-level Failure.
+    #
+    # The pipeline itself is output-free per ADR-0012 — no spinners, no
+    # progress lines, no stdout. Callers (the CLI verb today; a TUI
+    # Command tomorrow) render the outcome.
+    #
+    # Inputs:
+    #   adapter         — HostAdapter instance (already authenticated)
+    #   project         — Project struct
+    #   issue           — String/Integer issue number (used in branch name)
+    #   root            — Clone-root directory
+    #   allow_announce  — Boolean. Verb-level gating (e.g. --no-comment,
+    #                     `comment_on_fix?` config) is collapsed into this
+    #                     bool by the caller. The pipeline additionally
+    #                     skips announce when `viewer == project.owner`
+    #                     (you don't need to announce on your own repo).
+    #
+    # Returns Success(hash) on the happy path:
+    #   { fork: Operations::Fork::Result,
+    #     clone: Operations::Clone::Result,
+    #     branch: Operations::Branch::Result,
+    #     announce: Result (Success(:posted | :skipped) | Failure([:announce_failed, msg])) }
+    class FixPipeline < Dry::Operation
+      def initialize(fork: nil, clone: nil, branch: nil, announce: nil, git: nil)
+        super()
+        git ||= Git.new
+        @fork = fork || Operations::Fork.new
+        @clone = clone || Operations::Clone.new(git: git)
+        @branch = branch || Operations::Branch.new(git: git)
+        @announce = announce || Operations::Announce.new
+      end
+
+      # `Dry::Operation` wraps the method's final return value in `Success`,
+      # so the body returns a raw hash. `step` unwraps Success and short-
+      # circuits on Failure; Announce is called outside `step` because its
+      # Failure is informational (the fix has already happened).
+      def call(adapter:, project:, issue:, root:, allow_announce:)
+        fork_result = step @fork.call(adapter: adapter, project: project)
+        clone_result = step @clone.call(
+          adapter: adapter, project: project,
+          fork_clone_url: fork_result.clone_url, root: root
+        )
+        branch_result = step @branch.call(path: clone_result.path, issue: issue)
+
+        allow = allow_announce && fork_result.viewer != project.owner
+        announce_result = @announce.call(
+          adapter: adapter, project: project, issue: issue, allow: allow
+        )
+
+        {
+          fork: fork_result,
+          clone: clone_result,
+          branch: branch_result,
+          announce: announce_result
+        }
+      end
+    end
+  end
+end

--- a/lib/gem_contribute/operations/fork.rb
+++ b/lib/gem_contribute/operations/fork.rb
@@ -1,42 +1,34 @@
 # frozen_string_literal: true
 
+require "dry/monads"
+
 module GemContribute
   module Operations
     # Bootstrap step 1: ensure the viewer owns a fork of `project` (creating
-    # one if needed), and report what happened. Does no filesystem work —
-    # that's `Operations::Clone`'s job.
-    #
-    # Result fields mirror the adapter's `ForkResult` plus `upstream_url` (a
-    # convenience for the CLI summary so it doesn't have to ask the adapter
-    # again).
+    # one if needed). Returns a `Result` describing what happened, or a
+    # tagged `Failure` for the caller to render. Does no filesystem work
+    # — that's `Operations::Clone`'s job. Does no I/O — that's the caller's
+    # job (per ADR-0012).
     class Fork
+      include Dry::Monads[:result]
+
       Result = Data.define(:clone_url, :fork_url, :upstream_url, :viewer, :reused)
 
-      def initialize(stdout: $stdout)
-        @stdout = stdout
-      end
-
       def call(adapter:, project:)
-        @stdout.puts "Forking #{project.owner}/#{project.repo}..."
         fork = adapter.fork(project)
-        @stdout.puts status_line(fork, project)
-        Result.new(
-          clone_url: fork.clone_url,
-          fork_url: fork.fork_url,
-          upstream_url: adapter.repo_url(project.owner, project.repo),
-          viewer: fork.viewer,
-          reused: fork.reused
+        Success(
+          Result.new(
+            clone_url: fork.clone_url,
+            fork_url: fork.fork_url,
+            upstream_url: adapter.repo_url(project.owner, project.repo),
+            viewer: fork.viewer,
+            reused: fork.reused
+          )
         )
-      end
-
-      private
-
-      def status_line(fork, project)
-        if fork.reused
-          "  Reusing existing fork at #{fork.viewer}/#{project.repo}."
-        else
-          "  Forked → #{fork.viewer}/#{project.repo}."
-        end
+      rescue GemContribute::AuthRequired
+        Failure(:unauthenticated)
+      rescue GemContribute::AdapterError => e
+        Failure([:adapter_error, e.message])
       end
     end
   end

--- a/spec/gem_contribute/cli/fix_spec.rb
+++ b/spec/gem_contribute/cli/fix_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GemContribute::CLI::Fix do
   let(:resolver) { instance_double(GemContribute::Resolver) }
   let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
   let(:git) { instance_double(GemContribute::Git) }
-  let(:fork_cli) { instance_double(GemContribute::CLI::Fork) }
+  let(:pipeline) { instance_double(GemContribute::Operations::FixPipeline) }
   let(:clone_root) { File.join(tmpdir, "code", "oss") }
   let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
   let(:cli) do
@@ -23,7 +23,7 @@ RSpec.describe GemContribute::CLI::Fix do
       resolver: resolver, store: store,
       adapter_factory: ->(**) { adapter },
       git: git, clone_root: clone_root,
-      config: config, fork: fork_cli
+      config: config, pipeline: pipeline
     )
   end
 
@@ -34,7 +34,7 @@ RSpec.describe GemContribute::CLI::Fix do
     )
   end
   let(:target) { File.join(clone_root, "sidekiq", "sidekiq") }
-  let(:fork_info) do
+  let(:fork_data) do
     GemContribute::Operations::Fork::Result.new(
       clone_url: "https://github.com/alice/sidekiq.git",
       fork_url: "https://github.com/alice/sidekiq",
@@ -42,14 +42,16 @@ RSpec.describe GemContribute::CLI::Fix do
       viewer: "alice", reused: false
     )
   end
+  let(:clone_data) { GemContribute::Operations::Clone::Result.new(path: target, reused: false) }
+  let(:branch_data) { GemContribute::Operations::Branch::Result.new(name: "gem-contribute/issue-1234") }
+  let(:pipeline_success) do
+    Success(fork: fork_data, clone: clone_data, branch: branch_data, announce: Success(:posted))
+  end
 
   before do
     store.store("github.com", access_token: "gho_test")
     allow(resolver).to receive(:resolve).and_return(project)
-    allow(git).to receive(:checkout_branch)
-    allow(git).to receive(:branch_exists?).and_return(false)
-    allow(fork_cli).to receive(:bootstrap).with(adapter, project).and_return(Success([target, fork_info]))
-    allow(GemContribute::CLI::IssueAnnouncer).to receive(:announce_working).and_return(:posted)
+    allow(pipeline).to receive(:call).and_return(pipeline_success)
   end
 
   after { FileUtils.rm_rf(tmpdir) }
@@ -74,20 +76,22 @@ RSpec.describe GemContribute::CLI::Fix do
       resolver: resolver, store: store,
       adapter_factory: ->(**) { adapter },
       git: git, clone_root: nil,
-      fork: fork_cli
+      pipeline: pipeline
     )
     expect(cli_no_clone_root.run(["sidekiq/1"])).to eq(1)
     expect(stderr.string).to include("gem-contribute init")
   end
 
-  it "delegates the fork+clone bootstrap and then branches", :aggregate_failures do
+  it "delegates to FixPipeline and prints a summary", :aggregate_failures do
     expect(cli.run(["sidekiq/1234"])).to eq(0)
-    expect(fork_cli).to have_received(:bootstrap).with(adapter, project)
-    expect(git).to have_received(:checkout_branch).with(target, "gem-contribute/issue-1234")
+    expect(pipeline).to have_received(:call).with(
+      adapter: adapter, project: project, issue: "1234",
+      root: clone_root, allow_announce: true
+    )
     expect(stdout.string).to include(target)
     expect(stdout.string).to include("gem-contribute/issue-1234")
-    expect(stdout.string).to include(fork_info.upstream_url)
-    expect(stdout.string).to include(fork_info.fork_url)
+    expect(stdout.string).to include(fork_data.upstream_url)
+    expect(stdout.string).to include(fork_data.fork_url)
   end
 
   it "fails clearly if the gem doesn't resolve to github.com" do
@@ -101,16 +105,16 @@ RSpec.describe GemContribute::CLI::Fix do
     expect(stderr.string).to include("only github.com is supported")
   end
 
-  it "surfaces a Failure([:adapter_error, ...]) from the bootstrap with a friendly message" do
-    allow(fork_cli).to receive(:bootstrap)
+  it "surfaces a Failure([:adapter_error, ...]) from the pipeline with a friendly message" do
+    allow(pipeline).to receive(:call)
       .and_return(Failure([:adapter_error, "fork not reachable after 60s"]))
 
     expect(cli.run(["sidekiq/1"])).to eq(1)
     expect(stderr.string).to include("fix failed: fork not reachable")
   end
 
-  it "surfaces a Failure(:unauthenticated) from the bootstrap with the auth-login hint" do
-    allow(fork_cli).to receive(:bootstrap).and_return(Failure(:unauthenticated))
+  it "surfaces a Failure(:unauthenticated) from the pipeline with the auth-login hint" do
+    allow(pipeline).to receive(:call).and_return(Failure(:unauthenticated))
 
     expect(cli.run(["sidekiq/1"])).to eq(1)
     expect(stderr.string).to include("auth login")
@@ -125,7 +129,7 @@ RSpec.describe GemContribute::CLI::Fix do
         adapter_factory: ->(**) { adapter },
         git: git, clone_root: clone_root,
         post_clone_hooks: hooks,
-        config: config, fork: fork_cli
+        config: config, pipeline: pipeline
       )
     end
 
@@ -145,70 +149,61 @@ RSpec.describe GemContribute::CLI::Fix do
     end
   end
 
-  describe "issue comment integration" do
-    it "announces working on the issue by default" do
-      expect(cli.run(["sidekiq/1234"])).to eq(0)
-      expect(GemContribute::CLI::IssueAnnouncer).to have_received(:announce_working)
-        .with(adapter: adapter, project: project, issue: "1234",
-              stdout: stdout, stderr: stderr)
+  describe "announce gating (allow_announce passed to FixPipeline)" do
+    it "passes allow_announce: true by default" do
+      cli.run(["sidekiq/1234"])
+      expect(pipeline).to have_received(:call)
+        .with(hash_including(allow_announce: true))
     end
 
-    it "skips the announce when --no-comment is passed" do
-      expect(cli.run(["sidekiq/1234", "--no-comment"])).to eq(0)
-      expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+    it "passes allow_announce: false when --no-comment is given" do
+      cli.run(["sidekiq/1234", "--no-comment"])
+      expect(pipeline).to have_received(:call)
+        .with(hash_including(allow_announce: false))
     end
 
-    it "skips the announce when the issue's branch already exists locally (resuming)" do
-      FileUtils.mkdir_p(File.join(target, ".git"))
-      allow(git).to receive(:branch_exists?).with(target, "gem-contribute/issue-1234").and_return(true)
-
-      expect(cli.run(["sidekiq/1234"])).to eq(0)
-      expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
+    it "passes allow_announce: false when comment_on_fix is disabled in config" do
+      config.set("comment_on_fix", "false")
+      cli.run(["sidekiq/1234"])
+      expect(pipeline).to have_received(:call)
+        .with(hash_including(allow_announce: false))
     end
 
-    it "announces when the clone exists but the branch for this issue is new" do
-      # User worked on issue 4 yesterday (clone exists), now starting issue 1234 fresh.
-      FileUtils.mkdir_p(File.join(target, ".git"))
-      allow(git).to receive(:branch_exists?).with(target, "gem-contribute/issue-1234").and_return(false)
-
-      expect(cli.run(["sidekiq/1234"])).to eq(0)
-      expect(GemContribute::CLI::IssueAnnouncer).to have_received(:announce_working)
-    end
-
-    it "skips the announce when the viewer owns the upstream" do
-      owned = GemContribute::Project.new(
-        gem_name: "rubocop", host: "github.com",
-        owner: "alice", repo: "rubocop", metadata: {}
-      )
-      allow(resolver).to receive(:resolve).and_return(owned)
-      owned_target = File.join(clone_root, "alice", "rubocop")
-      allow(fork_cli).to receive(:bootstrap).with(adapter, owned).and_return(Success([owned_target, fork_info]))
-
-      expect(cli.run(["rubocop/1234"])).to eq(0)
-      expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
-    end
-
-    context "when comment_on_fix is false in config" do
-      before { config.set("comment_on_fix", "false") }
-
-      it "skips the announce" do
-        expect(cli.run(["sidekiq/1234"])).to eq(0)
-        expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
-      end
-    end
-
-    context "when a per-repo override turns it off" do
-      before do
-        File.write(File.join(tmpdir, "config.yml"),
-                   YAML.dump("comment_on_fix" => true,
-                             "comment_on_fix_overrides" => { "sidekiq/sidekiq" => false }))
-      end
-
-      it "skips the announce" do
-        expect(cli.run(["sidekiq/1234"])).to eq(0)
-        expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)
-      end
+    it "passes allow_announce: false when a per-repo override turns it off" do
+      File.write(File.join(tmpdir, "config.yml"),
+                 YAML.dump("comment_on_fix" => true,
+                           "comment_on_fix_overrides" => { "sidekiq/sidekiq" => false }))
+      cli.run(["sidekiq/1234"])
+      expect(pipeline).to have_received(:call)
+        .with(hash_including(allow_announce: false))
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
+
+  describe "announce outcome rendering" do
+    it "prints the 'Posted' line when pipeline returns Success(:posted)" do
+      cli.run(["sidekiq/1234"])
+      expect(stdout.string).to include("Posted 'working on this' comment to issue #1234")
+    end
+
+    it "stays silent when pipeline returns Success(:skipped)" do
+      allow(pipeline).to receive(:call).and_return(
+        Success(fork: fork_data, clone: clone_data, branch: branch_data, announce: Success(:skipped))
+      )
+      cli.run(["sidekiq/1234"])
+      expect(stdout.string).not_to include("Posted")
+    end
+
+    it "prints the soft-failure 'Note' on stderr when announce returned Failure" do
+      allow(pipeline).to receive(:call).and_return(
+        Success(fork: fork_data, clone: clone_data, branch: branch_data,
+                announce: Failure([:announce_failed, "GitHub returned 422"]))
+      )
+
+      expect(cli.run(["sidekiq/1234"])).to eq(0)
+      expect(stderr.string).to include("Note: couldn't post 'working on this' comment to issue #1234")
+      expect(stderr.string).to include("GitHub returned 422")
+      expect(stderr.string).to include("Continuing.")
+    end
+  end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/gem_contribute/cli/fix_spec.rb
+++ b/spec/gem_contribute/cli/fix_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "stringio"
+require "dry/monads"
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe GemContribute::CLI::Fix do
+  include Dry::Monads[:result]
+
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
   let(:tmpdir) { Dir.mktmpdir("gem-contribute-fix-") }
@@ -45,7 +48,7 @@ RSpec.describe GemContribute::CLI::Fix do
     allow(resolver).to receive(:resolve).and_return(project)
     allow(git).to receive(:checkout_branch)
     allow(git).to receive(:branch_exists?).and_return(false)
-    allow(fork_cli).to receive(:bootstrap).with(adapter, project).and_return([target, fork_info])
+    allow(fork_cli).to receive(:bootstrap).with(adapter, project).and_return(Success([target, fork_info]))
     allow(GemContribute::CLI::IssueAnnouncer).to receive(:announce_working).and_return(:posted)
   end
 
@@ -98,12 +101,19 @@ RSpec.describe GemContribute::CLI::Fix do
     expect(stderr.string).to include("only github.com is supported")
   end
 
-  it "surfaces an AdapterError from the bootstrap with a friendly message" do
+  it "surfaces a Failure([:adapter_error, ...]) from the bootstrap with a friendly message" do
     allow(fork_cli).to receive(:bootstrap)
-      .and_raise(GemContribute::AdapterError, "fork not reachable after 60s")
+      .and_return(Failure([:adapter_error, "fork not reachable after 60s"]))
 
     expect(cli.run(["sidekiq/1"])).to eq(1)
-    expect(stderr.string).to include("fork not reachable")
+    expect(stderr.string).to include("fix failed: fork not reachable")
+  end
+
+  it "surfaces a Failure(:unauthenticated) from the bootstrap with the auth-login hint" do
+    allow(fork_cli).to receive(:bootstrap).and_return(Failure(:unauthenticated))
+
+    expect(cli.run(["sidekiq/1"])).to eq(1)
+    expect(stderr.string).to include("auth login")
   end
 
   describe "with -e and -a flags" do
@@ -172,7 +182,7 @@ RSpec.describe GemContribute::CLI::Fix do
       )
       allow(resolver).to receive(:resolve).and_return(owned)
       owned_target = File.join(clone_root, "alice", "rubocop")
-      allow(fork_cli).to receive(:bootstrap).with(adapter, owned).and_return([owned_target, fork_info])
+      allow(fork_cli).to receive(:bootstrap).with(adapter, owned).and_return(Success([owned_target, fork_info]))
 
       expect(cli.run(["rubocop/1234"])).to eq(0)
       expect(GemContribute::CLI::IssueAnnouncer).not_to have_received(:announce_working)

--- a/spec/gem_contribute/cli/fork_spec.rb
+++ b/spec/gem_contribute/cli/fork_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "stringio"
+require "dry/monads"
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe GemContribute::CLI::Fork do
+  include Dry::Monads[:result]
+
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
   let(:tmpdir) { Dir.mktmpdir("gem-contribute-fork-") }
@@ -30,6 +33,7 @@ RSpec.describe GemContribute::CLI::Fork do
       viewer: "alice", reused: false
     )
   end
+  let(:clone_info) { GemContribute::Operations::Clone::Result.new(path: target_path, reused: false) }
   let(:cli) do
     described_class.new(
       stdout: stdout, stderr: stderr,
@@ -47,8 +51,8 @@ RSpec.describe GemContribute::CLI::Fork do
     before do
       store.store("github.com", access_token: "gho_test")
       allow(resolver).to receive(:resolve).and_return(project)
-      allow(fork_op).to receive(:call).and_return(fork_info)
-      allow(clone_op).to receive(:call).and_return(target_path)
+      allow(fork_op).to receive(:call).and_return(Success(fork_info))
+      allow(clone_op).to receive(:call).and_return(Success(clone_info))
     end
 
     it "exits 2 with usage when no gem name is given" do
@@ -96,6 +100,9 @@ RSpec.describe GemContribute::CLI::Fork do
         adapter: adapter, project: project,
         fork_clone_url: fork_info.clone_url, root: clone_root
       )
+      expect(stdout.string).to include("Forking sidekiq/sidekiq")
+      expect(stdout.string).to include("Forked → alice/sidekiq")
+      expect(stdout.string).to include("Cloned into #{target_path}")
       expect(stdout.string).to include("Forked and cloned")
       expect(stdout.string).to include("default branch")
       expect(stdout.string).to include(target_path)
@@ -117,21 +124,68 @@ RSpec.describe GemContribute::CLI::Fork do
         project: have_attributes(owner: "rubyevents", repo: "rubyevents", host: "github.com")
       )
     end
+
+    it "exits 1 with an adapter-error message when fork_op returns Failure(:adapter_error, ...)" do
+      allow(fork_op).to receive(:call).and_return(Failure([:adapter_error, "rate limit exceeded"]))
+
+      expect(cli.run(["sidekiq"])).to eq(1)
+      expect(stderr.string).to include("fork failed: rate limit exceeded")
+    end
+
+    it "exits 1 with the auth-login hint when fork_op returns Failure(:unauthenticated)" do
+      allow(fork_op).to receive(:call).and_return(Failure(:unauthenticated))
+
+      expect(cli.run(["sidekiq"])).to eq(1)
+      expect(stderr.string).to include("auth login")
+    end
   end
 
   describe "#bootstrap (the shared primitive)" do
-    it "calls the fork op then the clone op and returns [path, fork_info]" do
-      allow(fork_op).to receive(:call).and_return(fork_info)
-      allow(clone_op).to receive(:call).and_return(target_path)
+    it "calls the fork op then the clone op and returns Success([path, fork_info])" do
+      allow(fork_op).to receive(:call).and_return(Success(fork_info))
+      allow(clone_op).to receive(:call).and_return(Success(clone_info))
 
-      path, info = cli.bootstrap(adapter, project)
+      result = cli.bootstrap(adapter, project)
 
+      expect(result).to be_success
+      path, info = result.value!
       expect(path).to eq(target_path)
       expect(info).to eq(fork_info)
       expect(clone_op).to have_received(:call).with(
         adapter: adapter, project: project,
         fork_clone_url: fork_info.clone_url, root: clone_root
       )
+    end
+
+    it "short-circuits and returns the fork_op Failure without calling clone_op" do
+      allow(fork_op).to receive(:call).and_return(Failure([:adapter_error, "fork timed out"]))
+      allow(clone_op).to receive(:call)
+
+      result = cli.bootstrap(adapter, project)
+
+      expect(result).to eq(Failure([:adapter_error, "fork timed out"]))
+      expect(clone_op).not_to have_received(:call)
+    end
+
+    it "propagates a clone_op Failure" do
+      allow(fork_op).to receive(:call).and_return(Success(fork_info))
+      allow(clone_op).to receive(:call).and_return(Failure([:adapter_error, "git clone failed"]))
+
+      result = cli.bootstrap(adapter, project)
+
+      expect(result).to eq(Failure([:adapter_error, "git clone failed"]))
+    end
+
+    it "prints reuse messaging when both ops report reused: true" do
+      reused_fork = fork_info.with(reused: true)
+      reused_clone = GemContribute::Operations::Clone::Result.new(path: target_path, reused: true)
+      allow(fork_op).to receive(:call).and_return(Success(reused_fork))
+      allow(clone_op).to receive(:call).and_return(Success(reused_clone))
+
+      cli.bootstrap(adapter, project)
+
+      expect(stdout.string).to include("Reusing existing fork at alice/sidekiq")
+      expect(stdout.string).to include("Reusing existing clone at #{target_path}")
     end
   end
 end

--- a/spec/gem_contribute/cli/issue_announcer_spec.rb
+++ b/spec/gem_contribute/cli/issue_announcer_spec.rb
@@ -1,78 +1,6 @@
 # frozen_string_literal: true
 
-require "stringio"
-
 RSpec.describe GemContribute::CLI::IssueAnnouncer do
-  let(:stdout) { StringIO.new }
-  let(:stderr) { StringIO.new }
-  let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
-  let(:project) do
-    GemContribute::Project.new(
-      gem_name: "sidekiq", host: "github.com",
-      owner: "sidekiq", repo: "sidekiq", metadata: {}
-    )
-  end
-
-  describe ".announce_working" do
-    it "posts a comment and returns :posted when no marker is present" do
-      allow(adapter).to receive_messages(issue_comments: [], comment: { "id" => 1 })
-
-      result = described_class.announce_working(
-        adapter: adapter, project: project, issue: "1234",
-        stdout: stdout, stderr: stderr
-      )
-
-      expect(result).to eq(:posted)
-      expect(adapter).to have_received(:comment)
-        .with(project, issue: "1234", body: a_string_including(described_class::WORKING_MARKER))
-      expect(stdout.string).to include("Posted 'working on this' comment to issue #1234")
-    end
-
-    it "skips the post and returns :skipped when the marker is present" do
-      allow(adapter).to receive(:issue_comments).and_return(
-        [{ "body" => "Random earlier comment" },
-         { "body" => "#{described_class::WORKING_MARKER}\nI've started working on this." }]
-      )
-
-      result = described_class.announce_working(
-        adapter: adapter, project: project, issue: "1234",
-        stdout: stdout, stderr: stderr
-      )
-
-      expect(result).to eq(:skipped)
-      expect(adapter).not_to have_received(:comment) if defined?(adapter.comment)
-    end
-
-    it "soft-fails to :failed when the post raises AdapterError" do
-      allow(adapter).to receive(:issue_comments).and_return([])
-      allow(adapter).to receive(:comment)
-        .and_raise(GemContribute::AdapterError, "GitHub returned 422")
-
-      result = described_class.announce_working(
-        adapter: adapter, project: project, issue: "1234",
-        stdout: stdout, stderr: stderr
-      )
-
-      expect(result).to eq(:failed)
-      expect(stderr.string).to include("couldn't post 'working on this' comment")
-      expect(stderr.string).to include("Continuing.")
-    end
-
-    it "treats an AdapterError on the comment-listing call as 'not announced' and still posts" do
-      allow(adapter).to receive(:issue_comments)
-        .and_raise(GemContribute::AdapterError, "GitHub returned 500")
-      allow(adapter).to receive(:comment).and_return("id" => 2)
-
-      result = described_class.announce_working(
-        adapter: adapter, project: project, issue: "1234",
-        stdout: stdout, stderr: stderr
-      )
-
-      expect(result).to eq(:posted)
-      expect(adapter).to have_received(:comment)
-    end
-  end
-
   describe ".fetch_claim_index" do
     let(:claim_adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
 
@@ -105,6 +33,10 @@ RSpec.describe GemContribute::CLI::IssueAnnouncer do
 
       index = described_class.fetch_claim_index(claim_adapter)
       expect(index).to eq("foo/bar" => [9])
+    end
+
+    it "uses the same WORKING_MARKER constant as Operations::Announce" do
+      expect(described_class::MARKER).to eq(GemContribute::Operations::Announce::WORKING_MARKER)
     end
   end
 end

--- a/spec/gem_contribute/operations/announce_spec.rb
+++ b/spec/gem_contribute/operations/announce_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+RSpec.describe GemContribute::Operations::Announce do
+  include Dry::Monads[:result]
+
+  let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
+  let(:project) do
+    GemContribute::Project.new(
+      gem_name: "sidekiq", host: "github.com",
+      owner: "sidekiq", repo: "sidekiq", metadata: {}
+    )
+  end
+  let(:operation) { described_class.new }
+
+  describe "#call" do
+    it "returns Success(:skipped) immediately when allow: false" do
+      result = operation.call(adapter: adapter, project: project, issue: "1", allow: false)
+
+      expect(result).to eq(Success(:skipped))
+      expect(adapter).not_to have_received(:comment) if defined?(adapter.comment)
+    end
+
+    it "returns Success(:skipped) when the marker is already present in earlier comments" do
+      allow(adapter).to receive(:issue_comments).and_return(
+        [{ "body" => "Random earlier comment" },
+         { "body" => "#{described_class::WORKING_MARKER}\nSomeone already claimed." }]
+      )
+
+      result = operation.call(adapter: adapter, project: project, issue: "1234", allow: true)
+
+      expect(result).to eq(Success(:skipped))
+    end
+
+    it "posts the WORKING_BODY and returns Success(:posted) when no marker is present" do
+      allow(adapter).to receive_messages(issue_comments: [], comment: { "id" => 1 })
+
+      result = operation.call(adapter: adapter, project: project, issue: "1234", allow: true)
+
+      expect(result).to eq(Success(:posted))
+      expect(adapter).to have_received(:comment)
+        .with(project, issue: "1234", body: a_string_including(described_class::WORKING_MARKER))
+    end
+
+    it "treats a comment-list AdapterError as 'not announced' and still posts" do
+      allow(adapter).to receive(:issue_comments)
+        .and_raise(GemContribute::AdapterError, "GitHub returned 500")
+      allow(adapter).to receive(:comment).and_return("id" => 2)
+
+      result = operation.call(adapter: adapter, project: project, issue: "1234", allow: true)
+
+      expect(result).to eq(Success(:posted))
+    end
+
+    it "returns Failure([:announce_failed, message]) when the post raises AdapterError" do
+      allow(adapter).to receive_messages(issue_comments: [])
+      allow(adapter).to receive(:comment)
+        .and_raise(GemContribute::AdapterError, "GitHub returned 422")
+
+      result = operation.call(adapter: adapter, project: project, issue: "1234", allow: true)
+
+      expect(result).to eq(Failure([:announce_failed, "GitHub returned 422"]))
+    end
+  end
+end

--- a/spec/gem_contribute/operations/branch_spec.rb
+++ b/spec/gem_contribute/operations/branch_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+RSpec.describe GemContribute::Operations::Branch do
+  include Dry::Monads[:result]
+
+  let(:git) { instance_double(GemContribute::Git) }
+  let(:operation) { described_class.new(git: git) }
+
+  it "creates a gem-contribute/issue-<N> branch and returns Success(Result(name:))" do
+    allow(git).to receive(:checkout_branch)
+
+    result = operation.call(path: "/clone/path", issue: "1234")
+
+    expect(result).to be_success
+    expect(result.value!).to have_attributes(name: "gem-contribute/issue-1234")
+    expect(git).to have_received(:checkout_branch).with("/clone/path", "gem-contribute/issue-1234")
+  end
+
+  it "accepts an integer issue number" do
+    allow(git).to receive(:checkout_branch)
+
+    result = operation.call(path: "/clone/path", issue: 7)
+
+    expect(result.value!.name).to eq("gem-contribute/issue-7")
+  end
+
+  it "returns Failure([:adapter_error, message]) when git raises AdapterError" do
+    allow(git).to receive(:checkout_branch)
+      .and_raise(GemContribute::AdapterError, "fatal: branch already exists")
+
+    result = operation.call(path: "/clone/path", issue: "1")
+
+    expect(result).to eq(Failure([:adapter_error, "fatal: branch already exists"]))
+  end
+end

--- a/spec/gem_contribute/operations/clone_spec.rb
+++ b/spec/gem_contribute/operations/clone_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require "stringio"
+require "dry/monads"
 
 RSpec.describe GemContribute::Operations::Clone do
-  let(:stdout) { StringIO.new }
+  include Dry::Monads[:result]
+
   let(:tmpdir) { Dir.mktmpdir("gem-contribute-clone-op-") }
   let(:git) { instance_double(GemContribute::Git) }
   let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
@@ -13,7 +14,7 @@ RSpec.describe GemContribute::Operations::Clone do
       owner: "sidekiq", repo: "sidekiq", metadata: {}
     )
   end
-  let(:operation) { described_class.new(git: git, stdout: stdout) }
+  let(:operation) { described_class.new(git: git) }
   let(:target) { File.join(tmpdir, "sidekiq", "sidekiq") }
 
   before do
@@ -25,29 +26,39 @@ RSpec.describe GemContribute::Operations::Clone do
 
   after { FileUtils.rm_rf(tmpdir) }
 
-  it "clones the fork into <root>/<owner>/<repo> and adds an upstream remote" do
+  it "clones into <root>/<owner>/<repo>, adds an upstream remote, returns Success(reused: false)" do
     result = operation.call(adapter: adapter, project: project,
                             fork_clone_url: "https://github.com/alice/sidekiq.git",
                             root: tmpdir)
 
-    expect(result).to eq(target)
+    expect(result).to be_success
+    expect(result.value!).to have_attributes(path: target, reused: false)
     expect(git).to have_received(:clone).with("https://github.com/alice/sidekiq.git", target)
     expect(git).to have_received(:add_remote)
       .with(target, "upstream", "https://github.com/sidekiq/sidekiq.git")
-    expect(stdout.string).to include("Cloning into #{target}")
   end
 
-  it "reuses the existing clone when one is already present" do
+  it "returns Success(reused: true) and skips git.clone when the clone already exists" do
     FileUtils.mkdir_p(File.join(target, ".git"))
 
     result = operation.call(adapter: adapter, project: project,
                             fork_clone_url: "https://github.com/alice/sidekiq.git",
                             root: tmpdir)
 
-    expect(result).to eq(target)
+    expect(result).to be_success
+    expect(result.value!).to have_attributes(path: target, reused: true)
     expect(git).not_to have_received(:clone)
     expect(git).to have_received(:add_remote)
       .with(target, "upstream", "https://github.com/sidekiq/sidekiq.git")
-    expect(stdout.string).to include("Reusing existing clone at #{target}")
+  end
+
+  it "returns Failure([:adapter_error, message]) when git raises AdapterError" do
+    allow(git).to receive(:clone).and_raise(GemContribute::AdapterError, "git clone failed: 128")
+
+    result = operation.call(adapter: adapter, project: project,
+                            fork_clone_url: "https://github.com/alice/sidekiq.git",
+                            root: tmpdir)
+
+    expect(result).to eq(Failure([:adapter_error, "git clone failed: 128"]))
   end
 end

--- a/spec/gem_contribute/operations/fix_pipeline_spec.rb
+++ b/spec/gem_contribute/operations/fix_pipeline_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+RSpec.describe GemContribute::Operations::FixPipeline do
+  include Dry::Monads[:result]
+
+  let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
+  let(:project) do
+    GemContribute::Project.new(
+      gem_name: "sidekiq", host: "github.com",
+      owner: "sidekiq", repo: "sidekiq", metadata: {}
+    )
+  end
+
+  let(:fork_op) { instance_double(GemContribute::Operations::Fork) }
+  let(:clone_op) { instance_double(GemContribute::Operations::Clone) }
+  let(:branch_op) { instance_double(GemContribute::Operations::Branch) }
+  let(:announce_op) { instance_double(GemContribute::Operations::Announce) }
+
+  let(:fork_result) do
+    GemContribute::Operations::Fork::Result.new(
+      clone_url: "https://github.com/alice/sidekiq.git",
+      fork_url: "https://github.com/alice/sidekiq",
+      upstream_url: "https://github.com/sidekiq/sidekiq",
+      viewer: "alice", reused: false
+    )
+  end
+  let(:clone_result) do
+    GemContribute::Operations::Clone::Result.new(path: "/clones/sidekiq/sidekiq", reused: false)
+  end
+  let(:branch_result) { GemContribute::Operations::Branch::Result.new(name: "gem-contribute/issue-1234") }
+
+  let(:pipeline) do
+    described_class.new(fork: fork_op, clone: clone_op, branch: branch_op, announce: announce_op)
+  end
+
+  it "wires Fork → Clone → Branch → Announce and returns Success({fork:, clone:, branch:, announce:})",
+     :aggregate_failures do
+    allow(fork_op).to receive(:call).and_return(Success(fork_result))
+    allow(clone_op).to receive(:call).and_return(Success(clone_result))
+    allow(branch_op).to receive(:call).and_return(Success(branch_result))
+    allow(announce_op).to receive(:call).and_return(Success(:posted))
+
+    result = pipeline.call(adapter: adapter, project: project, issue: "1234",
+                           root: "/clones", allow_announce: true)
+
+    expect(result).to be_success
+    expect(result.value!).to eq(
+      fork: fork_result,
+      clone: clone_result,
+      branch: branch_result,
+      announce: Success(:posted)
+    )
+    expect(fork_op).to have_received(:call).with(adapter: adapter, project: project)
+    expect(clone_op).to have_received(:call).with(
+      adapter: adapter, project: project,
+      fork_clone_url: fork_result.clone_url, root: "/clones"
+    )
+    expect(branch_op).to have_received(:call).with(path: clone_result.path, issue: "1234")
+  end
+
+  it "passes allow: false to Announce when the viewer owns the upstream (fork.viewer == project.owner)" do
+    fork_self = fork_result.with(viewer: "sidekiq")
+    allow(fork_op).to receive(:call).and_return(Success(fork_self))
+    allow(clone_op).to receive(:call).and_return(Success(clone_result))
+    allow(branch_op).to receive(:call).and_return(Success(branch_result))
+    allow(announce_op).to receive(:call).and_return(Success(:skipped))
+
+    pipeline.call(adapter: adapter, project: project, issue: "1234",
+                  root: "/clones", allow_announce: true)
+
+    expect(announce_op).to have_received(:call).with(
+      adapter: adapter, project: project, issue: "1234", allow: false
+    )
+  end
+
+  it "passes allow: false to Announce when allow_announce: false" do
+    allow(fork_op).to receive(:call).and_return(Success(fork_result))
+    allow(clone_op).to receive(:call).and_return(Success(clone_result))
+    allow(branch_op).to receive(:call).and_return(Success(branch_result))
+    allow(announce_op).to receive(:call).and_return(Success(:skipped))
+
+    pipeline.call(adapter: adapter, project: project, issue: "1234",
+                  root: "/clones", allow_announce: false)
+
+    expect(announce_op).to have_received(:call).with(
+      adapter: adapter, project: project, issue: "1234", allow: false
+    )
+  end
+
+  it "short-circuits with Fork's Failure and never calls Clone/Branch/Announce" do
+    allow(fork_op).to receive(:call).and_return(Failure([:adapter_error, "fork timed out"]))
+    allow(clone_op).to receive(:call)
+    allow(branch_op).to receive(:call)
+    allow(announce_op).to receive(:call)
+
+    result = pipeline.call(adapter: adapter, project: project, issue: "1234",
+                           root: "/clones", allow_announce: true)
+
+    expect(result).to eq(Failure([:adapter_error, "fork timed out"]))
+    expect(clone_op).not_to have_received(:call)
+    expect(branch_op).not_to have_received(:call)
+    expect(announce_op).not_to have_received(:call)
+  end
+
+  it "short-circuits with Branch's Failure and does not call Announce" do
+    allow(fork_op).to receive(:call).and_return(Success(fork_result))
+    allow(clone_op).to receive(:call).and_return(Success(clone_result))
+    allow(branch_op).to receive(:call).and_return(Failure([:adapter_error, "branch exists"]))
+    allow(announce_op).to receive(:call)
+
+    result = pipeline.call(adapter: adapter, project: project, issue: "1234",
+                           root: "/clones", allow_announce: true)
+
+    expect(result).to eq(Failure([:adapter_error, "branch exists"]))
+    expect(announce_op).not_to have_received(:call)
+  end
+
+  it "still returns Success when Announce returns Failure (announce is informational)" do
+    allow(fork_op).to receive(:call).and_return(Success(fork_result))
+    allow(clone_op).to receive(:call).and_return(Success(clone_result))
+    allow(branch_op).to receive(:call).and_return(Success(branch_result))
+    allow(announce_op).to receive(:call).and_return(Failure([:announce_failed, "GitHub 422"]))
+
+    result = pipeline.call(adapter: adapter, project: project, issue: "1234",
+                           root: "/clones", allow_announce: true)
+
+    expect(result).to be_success
+    expect(result.value![:announce]).to eq(Failure([:announce_failed, "GitHub 422"]))
+  end
+end

--- a/spec/gem_contribute/operations/fork_spec.rb
+++ b/spec/gem_contribute/operations/fork_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require "stringio"
+require "dry/monads"
 
 RSpec.describe GemContribute::Operations::Fork do
-  let(:stdout) { StringIO.new }
+  include Dry::Monads[:result]
+
   let(:adapter) { instance_double(GemContribute::HostAdapters::GitHubAdapter) }
   let(:project) do
     GemContribute::Project.new(
@@ -11,14 +12,14 @@ RSpec.describe GemContribute::Operations::Fork do
       owner: "sidekiq", repo: "sidekiq", metadata: {}
     )
   end
-  let(:operation) { described_class.new(stdout: stdout) }
+  let(:operation) { described_class.new }
 
   before do
     allow(adapter).to receive(:repo_url).with("sidekiq", "sidekiq")
                                         .and_return("https://github.com/sidekiq/sidekiq")
   end
 
-  it "delegates to adapter.fork and packages the result with upstream_url" do
+  it "returns Success with the fork data and the upstream URL" do
     allow(adapter).to receive(:fork).with(project).and_return(
       GemContribute::HostAdapter::ForkResult.new(
         clone_url: "https://github.com/alice/sidekiq.git",
@@ -29,7 +30,8 @@ RSpec.describe GemContribute::Operations::Fork do
 
     result = operation.call(adapter: adapter, project: project)
 
-    expect(result).to have_attributes(
+    expect(result).to be_success
+    expect(result.value!).to have_attributes(
       clone_url: "https://github.com/alice/sidekiq.git",
       fork_url: "https://github.com/alice/sidekiq",
       upstream_url: "https://github.com/sidekiq/sidekiq",
@@ -37,26 +39,28 @@ RSpec.describe GemContribute::Operations::Fork do
     )
   end
 
-  it "prints a 'Forked' line when the fork was just created" do
-    allow(adapter).to receive(:fork).and_return(
-      GemContribute::HostAdapter::ForkResult.new(
-        clone_url: "x", fork_url: "y", viewer: "alice", reused: false
-      )
-    )
-
-    operation.call(adapter: adapter, project: project)
-    expect(stdout.string).to include("Forking sidekiq/sidekiq")
-    expect(stdout.string).to include("Forked → alice/sidekiq")
-  end
-
-  it "prints a 'Reusing existing fork' line when the fork already existed" do
+  it "preserves the reused flag from the adapter" do
     allow(adapter).to receive(:fork).and_return(
       GemContribute::HostAdapter::ForkResult.new(
         clone_url: "x", fork_url: "y", viewer: "alice", reused: true
       )
     )
 
-    operation.call(adapter: adapter, project: project)
-    expect(stdout.string).to include("Reusing existing fork at alice/sidekiq")
+    result = operation.call(adapter: adapter, project: project)
+    expect(result.value!.reused).to be(true)
+  end
+
+  it "returns Failure(:unauthenticated) when the adapter raises AuthRequired" do
+    allow(adapter).to receive(:fork).and_raise(GemContribute::AuthRequired, "github.com")
+
+    result = operation.call(adapter: adapter, project: project)
+    expect(result).to eq(Failure(:unauthenticated))
+  end
+
+  it "returns Failure([:adapter_error, message]) when the adapter raises AdapterError" do
+    allow(adapter).to receive(:fork).and_raise(GemContribute::AdapterError, "rate limit exceeded")
+
+    result = operation.call(adapter: adapter, project: project)
+    expect(result).to eq(Failure([:adapter_error, "rate limit exceeded"]))
   end
 end


### PR DESCRIPTION
## Summary

Implements ADR-0012 Phase 1 — the output-free service layer that ROADMAP Phase 1 depends on. One commit per issue, four issues:

| Commit | Issue | Title |
|---|---|---|
| `1df0bf8` | #25 | adopt dry-rb; `Operations::Fork`/`Clone` return `Result` |
| `a7ea469` | #26 | `Workflow#build_adapter` returns `Result`; retire `with_workflow_rescues` |
| `d9c670a` | #27 | extract `Operations::Branch` + `Announce`; build `Operations::FixPipeline` |
| `acc6fa8` | #28 | migrate `CLI::Fork`/`CLI::Fix` initializers to `dry-initializer` |

Net effect: every `Operations::*` class is output-free and returns `Success(...)` / `Failure(...)`. The `fix` flow is composed by `Operations::FixPipeline` (a `Dry::Operation` subclass). The CLI verbs are thin Result-pattern-matching shells.

## What changed

**New deps** (`gem-contribute.gemspec`): `dry-monads ~> 1.10`, `dry-operation ~> 1.1`, `dry-initializer ~> 3.2`.

**Operations layer:**
- `Operations::Fork`, `Operations::Clone` lose `stdout:`; return `Success(Result)` / `Failure(reason)`.
- `Operations::Clone::Result = Data.define(:path, :reused)` (was a bare path string).
- New `Operations::Branch` — `git checkout -b gem-contribute/issue-<N>`, returns `Result`.
- New `Operations::Announce` — posts/skips the "working on this" comment with internal gating (`allow:`); returns `Success(:posted | :skipped)` or `Failure([:announce_failed, msg])`.
- New `Operations::FixPipeline` — `dry-operation` composing Fork → Clone → Branch → Announce. Announce is called outside `step` because its Failure is informational.

**CLI verbs:**
- `CLI::Fix` swaps its `fork: CLI::Fork` dependency for `pipeline: Operations::FixPipeline`.
- `CLI::Fork` keeps its `bootstrap` shape but pattern-matches the new `Result` return.
- Both use `dry-initializer` declarations — the `# rubocop:disable Metrics/ParameterLists` comments are gone.

**Workflow mixin:**
- `build_adapter` returns `Success(adapter)` / `Failure(:unauthenticated)` (was nil + stderr).
- `with_workflow_rescues` removed entirely.

**Other:**
- `CLI::IssueAnnouncer` keeps `fetch_claim_index` (used by `scan` and `issues`) and exposes `MARKER` as an alias for `Operations::Announce::WORKING_MARKER`.
- Two trivial rubocop autocorrects from `bcf273d` (Style/Lambda in `cli.rb`, Layout/EmptyLinesAroundClassBody in `submit.rb`) bundled into commit 1.

## Test plan

- [x] `bin/rspec` — 217 examples, 0 failures (was 198 on main; +19 new specs across `Operations::Branch`, `Announce`, `FixPipeline`, plus failure-path coverage in `cli/fork_spec` and `cli/fix_spec`)
- [x] `bin/rubocop` — clean
- [ ] Smoke test the `fix` flow against a real issue once merged (e.g. `gem-contribute fix gem-contribute/5`)

## Notes for review

- **Best read commit-by-commit.** Each commit is internally consistent and self-explained; reading them in order shows the gradual move from raise-based control flow → Result-based.
- **`dry-monads` pattern matching:** `Failure([:tag, payload])` is the constructor; `Failure(:tag, payload)` is the pattern. `Failure#deconstruct` uses `Array()` semantics, which unwraps arrays one level. Trip-wire I hit during commit 1.
- **`Dry::Operation` subclassing (not include):** in 1.x, `Dry::Operation` is a class. Body returns a raw value, framework wraps in Success.
- **Soft-fail Announce:** Announce's Failure does not propagate as a pipeline-level Failure (the fix has succeeded; the comment is a nice-to-have). Pattern in `FixPipeline#call` is to call Announce outside `step`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)