### PR TITLE
ci: tighten PR template and enforce required sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,21 +2,27 @@
 
 <!-- One or two sentences. What changes, and why. The "why" is the part that's hard to recover later. -->
 
-## Review preference
+## Linked issue / ADR
 
-Lowering friction is the whole point of this project. Pick whichever fits — defaults to the first if you don't tick anything.
+<!--
+Issue # this closes (or "none — drive-by fix").
+For non-trivial changes: which ADR(s) does this touch? If you skipped that step, write "no ADR" plus a one-line reason.
+-->
 
-- [ ] **Ship it.** Review for correctness, tests, and design fit. Skip style nits unless they're load-bearing.
-- [ ] **Full review, please.** Feedback on style, naming, idioms, and alternative designs welcome. I want the deep version, whether to learn the Ruby way or to stress-test a pattern I'm trying.
-
-## Working agreement check
+## Working agreement
 
 - [ ] Single concern (multi-concern PRs get bounced — see [CLAUDE.md](../CLAUDE.md))
-- [ ] ADRs touched: <!-- list ADR numbers, or "none" -->
 - [ ] `bin/rubocop` and `bin/rspec` pass locally
 - [ ] New behavior has a test; bug fix has a regression test
 - [ ] Async work goes through Rooibos Commands (no direct threads / `Async` / synchronous shellouts)
 
+## Test plan
+
+<!--
+How was this verified? Spec output, manual smoke, screenshots — whatever applies.
+"`bin/rspec` passes" is the floor, not a test plan.
+-->
+
 ## Notes for reviewer
 
-<!-- Tradeoffs, open questions, follow-ups — anything not obvious from the diff. -->
+<!-- Tradeoffs, open questions, follow-ups — anything not obvious from the diff. Delete the section if there's nothing to add. -->

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,100 @@
+name: PR template check
+
+# Verifies that PR descriptions include all required sections from
+# .github/PULL_REQUEST_TEMPLATE.md. Posts (or updates) a single comment
+# listing what's missing, and fails the check until the body is fixed.
+#
+# Security note: pull_request_target gives us write access to comment
+# back on the PR. We never check out PR HEAD; the body is read via the
+# event payload (data, not code).
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  template-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required sections
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          MARKER="<!-- pr-template-check -->"
+
+          # Required headings — must appear verbatim somewhere in the body.
+          required=(
+            "## Summary"
+            "## Linked issue / ADR"
+            "## Working agreement"
+            "## Test plan"
+          )
+          # "## Notes for reviewer" is intentionally optional — the template
+          # tells contributors to delete it when there's nothing to add.
+
+          missing=()
+          for heading in "${required[@]}"; do
+            if ! grep -Fq "$heading" <<< "${PR_BODY:-}"; then
+              missing+=("$heading")
+            fi
+          done
+
+          # Strip HTML comments and template placeholder text, then check
+          # the body has *some* substance. Catches PRs filed with the raw
+          # unmodified template.
+          stripped=$(printf '%s' "${PR_BODY:-}" | perl -0777 -pe 's/<!--.*?-->//gs')
+          # Drop heading lines and checklist scaffolding; what's left should
+          # be the contributor's own prose.
+          prose=$(printf '%s' "$stripped" | grep -Ev '^\s*(##|- \[[ x]\]|$)' || true)
+          prose_chars=$(printf '%s' "$prose" | tr -d '[:space:]' | wc -c | tr -d ' ')
+
+          # Find any prior bot comment so we can edit instead of stacking.
+          prior_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$MARKER\"))) | .id" \
+            | head -n1)
+
+          if [ ${#missing[@]} -eq 0 ] && [ "$prose_chars" -ge 40 ]; then
+            echo "PR body looks good."
+            if [ -n "$prior_id" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$prior_id" \
+                -f body="$MARKER
+✅ PR template check passed. Thanks for filling out the template."
+            fi
+            exit 0
+          fi
+
+          {
+            echo "$MARKER"
+            echo "👋 This PR is missing pieces from the [PR template](https://github.com/$REPO/blob/main/.github/PULL_REQUEST_TEMPLATE.md):"
+            echo ""
+            if [ ${#missing[@]} -gt 0 ]; then
+              echo "**Missing sections:**"
+              for m in "${missing[@]}"; do
+                echo "- \`$m\`"
+              done
+              echo ""
+            fi
+            if [ "$prose_chars" -lt 40 ]; then
+              echo "**Body looks unfilled** — the template comments are still there but no actual content has been written. Please fill in at least the Summary and Test plan."
+              echo ""
+            fi
+            echo "Edit the PR description (no new commit needed) and the check will re-run automatically. See [CLAUDE.md](https://github.com/$REPO/blob/main/CLAUDE.md) for why these sections matter."
+          } > /tmp/comment.md
+
+          if [ -n "$prior_id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$prior_id" \
+              -F body=@/tmp/comment.md
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+          fi
+
+          echo "::error::PR template is incomplete — see the bot comment on the PR."
+          exit 1


### PR DESCRIPTION
## Summary

Tightens `.github/PULL_REQUEST_TEMPLATE.md` and adds an automated check that fails until a PR body fills in the required sections. Motivated by [#51](https://github.com/cdhagmann/gem-contribute/pull/51) (mine — skipped half the template) and [#52](https://github.com/cdhagmann/gem-contribute/pull/52) (drive-by — skipped all of it).

## Linked issue / ADR

No issue, no ADR. This is tooling on the contribution path, not a code-architecture decision.

## Working agreement

- [x] Single concern (template change + the check that enforces it)
- [x] `bin/rubocop` and `bin/rspec` pass locally — no Ruby touched
- [x] New behavior has a test — manually verified workflow logic; the check itself will run against this PR once merged to main
- [x] Async work goes through Rooibos Commands — N/A

## Test plan

- Reviewed the new template by filling it out for this very PR; sections feel load-bearing.
- Walked through the workflow's bash logic by hand against three scenarios: full body (passes), heading-only body (fails on prose check), missing-section body (fails on heading check).
- Workflow won't actually run against this PR — it lives on `main` after merge, so the first PR to be checked is the one *after* this one.

## Template changes

- **Dropped:** "Review preference" (Ship it / Full review checkboxes). I never tick them; the default is fine.
- **Promoted:** "ADRs touched:" line inside the old checklist → standalone `## Linked issue / ADR` section. Forces a real answer instead of a checkbox no one fills in.
- **Added:** `## Test plan` section. CLAUDE.md says "test what's testable" — making it a section not a checkbox surfaces *how* it was tested, not just whether.
- **Kept:** Single-concern, rubocop/rspec, tests, Rooibos Commands checklist (renamed `Working agreement check` → `Working agreement`).
- **Kept:** Notes for reviewer, with explicit "delete this section if nothing to add" so it doesn't become noise.

## Workflow choices

- **Trigger:** `pull_request_target` (opened/edited/reopened/synchronize). Matches the existing `auto-merge-kicked-tires.yml` pattern. PR body is read from the event payload — never check out PR HEAD, so this is safe even on PRs from forks.
- **Comment idempotency:** uses a hidden `<!-- pr-template-check -->` marker. Edits the existing bot comment rather than stacking new ones on every push.
- **"Notes for reviewer" is intentionally optional.** The template tells you to delete it when there's nothing to say. Required = noise.
- **Substance check:** strips HTML comments and heading/checklist scaffolding, then requires ≥40 chars of prose. Catches "filed PR with raw template, didn't actually fill anything in."
- **Failure mode:** sets the check to red. Branch protection / required-status-check is a separate, manual flip — wanted to land the workflow first and validate it works before making merges depend on it.

## Notes for reviewer

- The first PR to be checked is the next one after this lands. If the logic has a bug, the symptom will be a false-positive on a real PR — easy to roll forward by editing the workflow.
- I considered going the mlflow auto-close route. Skipping it: at this repo's volume, manual close (with the ScheduleWakeup we already set up for [#52](https://github.com/cdhagmann/gem-contribute/pull/52)) is plenty. The check failing is enough friction to deter low-effort PRs without being hostile to first-timers who genuinely just missed a section.
