### PR TITLE
docs(roadmap+readme): descope v1.0 to CLI-only — ADR-0015, closes #46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here. The format is based
 
 ## [Unreleased]
 
+### Changed
+
+- README rewritten for the v1 audience. Status section now describes the v1.0 / v1.x / v2.0 sequencing (CLI at 1.0; Bundler + RubyGems plugins and multi-host adapters at 1.x; Rooibos TUI at 2.0) and points at [`docs/ROADMAP.md`](docs/ROADMAP.md) and [ADR-0015](docs/adr/0015-descope-v1-cli-only.md) for detail. Workshop framing removed (closes [#46](https://github.com/cdhagmann/gem-contribute/issues/46)).
+
 ## [0.3.1] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ The premise: the gems in your `Gemfile.lock` are the projects you have the most 
 
 ## Status
 
-Early. v0.1 is a CLI. A Rooibos TUI is planned (see [issue #2](https://github.com/cdhagmann/gem-contribute/issues/2)). This is being built as a workshop project for **[Blue Ridge Ruby 2026](https://blueridgeruby.com)**. Expect rough edges through the conference.
+v0.x; the first 1.0-track release ships via [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) on rubygems.org once the polish phase lands.
+
+The 1.0 surface is the standalone CLI shown above. The roadmap that follows it:
+
+- **v1.x** — `bundle contribute` and `gem contribute` plugins (so the tool is reachable from whatever invocation surface you're already in), plus multi-host adapters (GitLab, gem.coop). Same CLI shape; additional entry points and additional sources.
+- **v2.0** — Rooibos TUI as the bare-invocation experience for `gem-contribute`. Major version because bare-invocation behavior changes when the TUI auto-launches. ([issue #2](https://github.com/cdhagmann/gem-contribute/issues/2))
+
+[`docs/ROADMAP.md`](docs/ROADMAP.md) has the detail; [ADR-0015](docs/adr/0015-descope-v1-cli-only.md) explains why this sequencing.
 
 ## Install
 
@@ -89,9 +96,7 @@ See [`docs/design.md`](docs/design.md) for the architecture overview and [`docs/
 
 ## Contributing
 
-The tool is *for* finding contributable projects, so it had better be one. See [`CONTRIBUTING.md`](CONTRIBUTING.md). Issues tagged `good first issue` are real and reviewed.
-
-If you're attending Blue Ridge Ruby 2026 and arrived here from the workshop, see [`docs/workshop.md`](docs/workshop.md) for the exercises.
+The tool is *for* finding contributable projects, so it had better be one. See [`CONTRIBUTING.md`](CONTRIBUTING.md). Issues tagged [`good first issue`](https://github.com/cdhagmann/gem-contribute/labels/good%20first%20issue) are real and reviewed; issues with [`v1.x`](https://github.com/cdhagmann/gem-contribute/labels/v1.x) and [`v2.0`](https://github.com/cdhagmann/gem-contribute/labels/v2.0) labels indicate which release they're targeted at.
 
 ## Disclosure
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,10 +31,10 @@ This document is the plan. Decisions still in flight live in [`OPEN_QUESTIONS.md
 - **ADR-0012 service layer (Phase 1).** dry-monads `Result`, dry-operation pipelines, dry-initializer initializers, output-free `Operations::*`. Merged via [PR #48](https://github.com/cdhagmann/gem-contribute/pull/48) on 2026-05-04.
 - **Basic CI.** rubocop + rspec on push/PR landed via [PR #21](https://github.com/cdhagmann/gem-contribute/pull/21) (closes [#7](https://github.com/cdhagmann/gem-contribute/issues/7)). Plugin-install smoke and gated integration tests still pending under [#43](https://github.com/cdhagmann/gem-contribute/issues/43).
 - **PR template + automated check** ([PR #53](https://github.com/cdhagmann/gem-contribute/pull/53)). Tooling, not part of the v1 phases per se.
+- **ADR-0012 Phase 2 (CLI output pipeline).** `Output::Standard`/`Output::Null`, `tty-spinner`-backed `#progress`, `tty-prompt` in Init. Merged via [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51) on 2026-05-04.
 
 ## In flight
 
-- **ADR-0012 Phase 2 (CLI output pipeline)** — `Output::Standard`/`Output::Null`, `tty-spinner`, `tty-prompt`. Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51).
 - **Release infrastructure (Phase 6, partial)** — `release.yml` Trusted Publishing workflow + 0.3.1 cut. Open in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55).
 
 ## What hasn't started
@@ -93,9 +93,9 @@ Made every operation output-free and Result-returning. This is what lets the eve
 
 ---
 
-## Phase 2 — CLI pipeline (ADR-0012 Phase 2) (in flight)
+## Phase 2 — CLI pipeline (ADR-0012 Phase 2) (DONE)
 
-Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51). Move CLI verbs to a semantic output abstraction so the look-and-feel can evolve independently of the service layer.
+Moved CLI verbs to a semantic output abstraction so the look-and-feel can evolve independently of the service layer. Merged via [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51) on 2026-05-04.
 
 **Steps:**
 
@@ -106,15 +106,15 @@ Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51). Move CLI 
 5. Replace `CLI::Init`'s `stdout.print` + `@gets` with `tty-prompt`.
 
 **Acceptance:**
-- [ ] No raw `puts` to `@stdout`/`@stderr` in `lib/gem_contribute/cli/`
-- [ ] Long operations show a spinner in TTY contexts and a plain line in non-TTY contexts
-- [ ] `Init`'s test suite no longer mocks `gets`
-- [ ] User-visible CLI output unchanged for non-interactive flows; spinners appear in interactive ones
+- [x] No raw `puts` to `@stdout`/`@stderr` in `lib/gem_contribute/cli/`
+- [x] Long operations show a spinner in TTY contexts and a plain line in non-TTY contexts
+- [x] `Init`'s test suite no longer mocks `gets`
+- [x] User-visible CLI output unchanged for non-interactive flows; spinners appear in interactive ones
 
 **Issues:**
-- [ ] [#29](https://github.com/cdhagmann/gem-contribute/issues/29) — `Output::Standard` and `Output::Null`; migrate CLI verbs off raw stdout/stderr
-- [ ] [#30](https://github.com/cdhagmann/gem-contribute/issues/30) — `tty-spinner`-backed `#progress`
-- [ ] [#31](https://github.com/cdhagmann/gem-contribute/issues/31) — `CLI::Init` uses `tty-prompt`
+- [x] [#29](https://github.com/cdhagmann/gem-contribute/issues/29) — `Output::Standard` and `Output::Null`; migrate CLI verbs off raw stdout/stderr
+- [x] [#30](https://github.com/cdhagmann/gem-contribute/issues/30) — `tty-spinner`-backed `#progress`
+- [x] [#31](https://github.com/cdhagmann/gem-contribute/issues/31) — `CLI::Init` uses `tty-prompt`
 
 ---
 
@@ -144,7 +144,7 @@ Everything required to call it 1.0 and not 0.x. Phase number stays at 6 to prese
 ## Sequencing logic for v1.0
 
 - **Phase 0 → 1 → 2 → 6** in strict order. Each unblocks the next.
-- 1.0 ships when Phase 6 is acceptably complete. Realistically: a few small PRs after PR #51 and PR #55 land.
+- 1.0 ships when Phase 6 is acceptably complete. Phases 0, 1, and 2 are done; the remaining work is the polish + release set in Phase 6, with [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55) cutting the first publish (0.3.1) once it merges.
 - v1.x and v2.0 work cannot start until 1.0 is on rubygems with at least a small user base.
 
 ---
@@ -274,7 +274,7 @@ All roadmap work is tracked on the issue tracker. Filter by label:
 |---|---|---|
 | Phase 0 (DONE) | #23, #24 | Two doc sweeps |
 | Phase 1 (DONE) | #25–#28 | Service layer (ADR-0012) |
-| Phase 2 (in flight) | #29–#31 | CLI output pipeline |
+| Phase 2 (DONE) | #29–#31 | CLI output pipeline |
 | Phase 6 (v1.0 polish + release) | #1, #9, #10, #40–#46, #54 | Release infra + papercut polish |
 | v1.x | #3, #8, #38, #39, #47, #49, #50 | Plugins, multi-host, extensions |
 | v2.0 | #2 (umbrella), #13, #32–#37 | Rooibos TUI |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -136,7 +136,7 @@ Everything required to call it 1.0 and not 0.x. Phase number stays at 6 to prese
 - [ ] [#43](https://github.com/cdhagmann/gem-contribute/issues/43) — CI workflow: rubocop + rspec done; gated integration tests still pending; plugin install smoke deferred to v1.x with plugins
 - [x] [#44](https://github.com/cdhagmann/gem-contribute/issues/44) — Release workflow with **Trusted Publishing (OIDC)** (in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55), goes live with the 0.3.1 cut)
 - [ ] 🌱 [#45](https://github.com/cdhagmann/gem-contribute/issues/45) — Archive workshop docs to `docs/archive/`
-- [ ] [#46](https://github.com/cdhagmann/gem-contribute/issues/46) — README rewrite for v1 audience (CLI-only framing per ADR-0015; "TUI coming in v2.0", "plugins coming in v1.x")
+- [x] [#46](https://github.com/cdhagmann/gem-contribute/issues/46) — README rewrite for v1 audience (CLI-only framing per ADR-0015; "TUI coming in v2.0", "plugins coming in v1.x") — done in [PR #56](https://github.com/cdhagmann/gem-contribute/pull/56)
 - [ ] Tag `v1.0.0`, push to rubygems
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
-# Roadmap to v1
+# Roadmap
 
-**Goal:** v1 of `gem-contribute` ships a single gem with three entry points against `github.com`:
+**v1.0** ships the standalone `gem-contribute` CLI on rubygems.org against `github.com`. Output-free service layer (per [ADR-0012](adr/0012-output-free-service-objects-three-interface-architecture.md)), real release on rubygems with Trusted Publishing, CHANGELOG, CI.
 
-1. **Standalone CLI** — `gem-contribute <verb>`. Bare invocation (no subcommand) launches the **Rooibos TUI** (project list → issue list → issue detail → CONTRIBUTING viewer + auth overlay).
-2. **Bundler plugin** — `bundle contribute [verb]`. CLI-only. Bare invocation runs a default summary verb (TBD: `scan` or `list all`).
-3. **RubyGems plugin** — `gem contribute [verb]`. CLI-only. Same shape as Bundler plugin.
+**v1.x** adds Bundler plugin (`bundle contribute`), RubyGems plugin (`gem contribute`), multi-host adapters (GitLab, gem.coop), and other extensions that ride the existing CLI shape. Architecture for these is locked in (per [ADR-0014](adr/0014-ship-bundler-and-rubygems-plugins.md)); shipping is sequenced after 1.0 lands real users.
 
-All three share the same output-free service layer (per [ADR-0012](adr/0012-output-free-service-objects-three-interface-architecture.md)). All three are tested. v1 has a real release on rubygems.org, a CHANGELOG, and CI.
+**v2.0** ships the Rooibos TUI as the bare-invocation experience for `gem-contribute`. Major version because bare-invocation behavior changes.
+
+The descope of TUI and plugins from v1.0 is recorded in [ADR-0015](adr/0015-descope-v1-cli-only.md).
 
 This document is the plan. Decisions still in flight live in [`OPEN_QUESTIONS.md`](OPEN_QUESTIONS.md) and get resolved one at a time.
 
@@ -15,9 +15,10 @@ This document is the plan. Decisions still in flight live in [`OPEN_QUESTIONS.md
 ## Decision history (the short version)
 
 - **Workshop is over** (2026-05-02). Decisions made primarily for workshop scope are reversed.
-- **TUI framework: Rooibos** (per [ADR-0013](adr/0013-revert-to-rooibos.md), supersedes ADR-0010). Bubbletea-ruby was a workshop-driven choice; Rooibos enables the post-v1 world map view (issue #5) and matches the project's verbs better.
-- **Three entry points, one gem** (per [ADR-0014](adr/0014-ship-bundler-and-rubygems-plugins.md), amends ADR-0006 and ADR-0012). Standalone binary + Bundler plugin + RubyGems plugin all live in the `gem-contribute` gem.
-- **GitHub-only at v1.0.** GitLab/Codeberg adapters are v1.x territory. ADR-0011's architecture is the bet that pays off there.
+- **TUI framework: Rooibos** (per [ADR-0013](adr/0013-revert-to-rooibos.md), supersedes ADR-0010). Bubbletea-ruby was a workshop-driven choice; Rooibos enables the world map view (issue #5) and matches the project's verbs better.
+- **Single gem with three entry points** (per [ADR-0014](adr/0014-ship-bundler-and-rubygems-plugins.md), amends ADR-0006 and ADR-0012). Standalone binary + Bundler plugin + RubyGems plugin all live in the `gem-contribute` gem. Architecture decision.
+- **v1.0 = CLI alone; plugins at v1.x; TUI at v2.0** (per [ADR-0015](adr/0015-descope-v1-cli-only.md), amends ADR-0014). Sequencing decision; ADR-0014's architecture stands.
+- **GitHub-only at v1.0.** GitLab/Codeberg/gem.coop adapters are v1.x territory. ADR-0011's architecture is the bet that pays off there.
 - **Service layer is output-free** (per ADR-0012). dry-monads `Result` returns; dry-operation pipelines; no `stdout:` in operations.
 
 ---
@@ -29,36 +30,41 @@ This document is the plan. Decisions still in flight live in [`OPEN_QUESTIONS.md
 - **HostAdapter cleanup.** ADR-0011 work landed: adapter owns host verbs, Operations layer composes them, CLI verbs compose Operations.
 - **ADR-0012 service layer (Phase 1).** dry-monads `Result`, dry-operation pipelines, dry-initializer initializers, output-free `Operations::*`. Merged via [PR #48](https://github.com/cdhagmann/gem-contribute/pull/48) on 2026-05-04.
 - **Basic CI.** rubocop + rspec on push/PR landed via [PR #21](https://github.com/cdhagmann/gem-contribute/pull/21) (closes [#7](https://github.com/cdhagmann/gem-contribute/issues/7)). Plugin-install smoke and gated integration tests still pending under [#43](https://github.com/cdhagmann/gem-contribute/issues/43).
-
-## What hasn't started
-
-- TUI
-- Bundler plugin
-- RubyGems plugin
-- Remaining release infrastructure (MAINTAINER doc, release workflow, README rewrite)
+- **PR template + automated check** ([PR #53](https://github.com/cdhagmann/gem-contribute/pull/53)). Tooling, not part of the v1 phases per se.
 
 ## In flight
 
 - **ADR-0012 Phase 2 (CLI output pipeline)** — `Output::Standard`/`Output::Null`, `tty-spinner`, `tty-prompt`. Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51).
+- **Release infrastructure (Phase 6, partial)** — `release.yml` Trusted Publishing workflow + 0.3.1 cut. Open in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55).
+
+## What hasn't started
+
+- Remaining release infrastructure (CONTRIBUTING.md polish, README rewrite, plugin smoke tests, the v1.0 tag itself)
+- v1.x work (plugins, multi-host adapters)
+- v2.0 work (Rooibos TUI)
 
 ---
+
+# v1.0 — Standalone CLI
 
 ## Phase 0 — Reset workshop-era decisions (DONE)
 
 Two new ADRs landed:
 
 - [ADR-0013](adr/0013-revert-to-rooibos.md) — Rooibos as the TUI framework, superseding ADR-0010.
-- [ADR-0014](adr/0014-ship-bundler-and-rubygems-plugins.md) — Bundler + RubyGems plugins ship at v1, single gem.
+- [ADR-0014](adr/0014-ship-bundler-and-rubygems-plugins.md) — Bundler + RubyGems plugins ship inside `gem-contribute`, single gem.
 
 ADR header sweep done in commit `00f5a4c`. Doc sweeps:
-- [x] 🌱 [#23](https://github.com/cdhagmann/gem-contribute/issues/23) — Sweep `docs/design.md` for residual bubbletea references (no-op; doc was already clean)
-- [x] 🌱 [#24](https://github.com/cdhagmann/gem-contribute/issues/24) — Sweep `docs/design-interface-layer.md` for "bubbletea" → "Rooibos" and update gem-plugin section
+- [x] 🌱 [#23](https://github.com/cdhagmann/gem-contribute/issues/23) — Sweep `docs/design.md` for residual bubbletea references
+- [x] 🌱 [#24](https://github.com/cdhagmann/gem-contribute/issues/24) — Sweep `docs/design-interface-layer.md` for "bubbletea" → "Rooibos"
+
+A third descope ADR landed later: [ADR-0015](adr/0015-descope-v1-cli-only.md) — moves plugins to v1.x and TUI to v2.0.
 
 ---
 
 ## Phase 1 — Service layer (ADR-0012 Phase 1) (DONE)
 
-Made every operation output-free and Result-returning. This is what lets the TUI and the two plugins reuse the same code paths the standalone CLI uses. Merged via [PR #48](https://github.com/cdhagmann/gem-contribute/pull/48) on 2026-05-04.
+Made every operation output-free and Result-returning. This is what lets the eventual TUI and plugins reuse the same code paths the standalone CLI uses. Merged via [PR #48](https://github.com/cdhagmann/gem-contribute/pull/48) on 2026-05-04.
 
 **Steps:**
 
@@ -112,9 +118,92 @@ Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51). Move CLI 
 
 ---
 
-## Phase 3 — Rooibos TUI
+## Phase 6 — Polish, release infrastructure, v1.0
 
-**Umbrella issue:** [#2 — Implement Rooibos TUI on top of the v0.1 CLI](https://github.com/cdhagmann/gem-contribute/issues/2). The major work. Per design.md and ADR-0013.
+Everything required to call it 1.0 and not 0.x. Phase number stays at 6 to preserve the existing `phase:6` issue labels and historical references; in the post-ADR-0015 ordering it's the third remaining v1.0 phase.
+
+**Pre-existing user-facing issues that fold into this phase:**
+- [ ] 🌱 [#1 — Add `preferred_labels` config so non-canonical good-first-issue labels are caught](https://github.com/cdhagmann/gem-contribute/issues/1)
+- [ ] 🌱 [#9 — Add `--label LABEL` flag to scan and issues for one-off overrides](https://github.com/cdhagmann/gem-contribute/issues/9) (related to #1)
+- [ ] 🌱 [#10 — Friendlier message when `fix` runs against a repo you own](https://github.com/cdhagmann/gem-contribute/issues/10)
+- [ ] 🌱 [#54 — Make `fix` re-runs idempotent (don't error when branch already exists)](https://github.com/cdhagmann/gem-contribute/issues/54)
+
+**Release infrastructure:**
+- [ ] 🌱 [#40](https://github.com/cdhagmann/gem-contribute/issues/40) — Add CHANGELOG.md *(file exists; close when satisfied)*
+- [ ] 🌱 [#41](https://github.com/cdhagmann/gem-contribute/issues/41) — Add CONTRIBUTING.md *(file exists; close when satisfied)*
+- [ ] [#42](https://github.com/cdhagmann/gem-contribute/issues/42) — MAINTAINER.md (release process, OAuth App, plugin verification) *(release-process and OAuth sections done in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55); plugin verification deferred to v1.x with the plugins themselves)*
+- [ ] OAuth App: stay on personal-account App for v1.0 (per Q13); migrate when rate limits bite
+- [ ] [#43](https://github.com/cdhagmann/gem-contribute/issues/43) — CI workflow: rubocop + rspec done; gated integration tests still pending; plugin install smoke deferred to v1.x with plugins
+- [x] [#44](https://github.com/cdhagmann/gem-contribute/issues/44) — Release workflow with **Trusted Publishing (OIDC)** (in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55), goes live with the 0.3.1 cut)
+- [ ] 🌱 [#45](https://github.com/cdhagmann/gem-contribute/issues/45) — Archive workshop docs to `docs/archive/`
+- [ ] [#46](https://github.com/cdhagmann/gem-contribute/issues/46) — README rewrite for v1 audience (CLI-only framing per ADR-0015; "TUI coming in v2.0", "plugins coming in v1.x")
+- [ ] Tag `v1.0.0`, push to rubygems
+
+---
+
+## Sequencing logic for v1.0
+
+- **Phase 0 → 1 → 2 → 6** in strict order. Each unblocks the next.
+- 1.0 ships when Phase 6 is acceptably complete. Realistically: a few small PRs after PR #51 and PR #55 land.
+- v1.x and v2.0 work cannot start until 1.0 is on rubygems with at least a small user base.
+
+---
+
+# v1.x — Plugins, multi-host adapters, polish extensions
+
+Each item below is independently shippable as a 1.x point release (1.1, 1.2, …). Sequencing is a runtime call informed by what 1.0 users actually ask for.
+
+## Bundler plugin (`bundle contribute`)
+
+A `plugins.rb` entry point at the root of the gem registers a Bundler plugin command per Bundler convention. Delegates to the same dispatch table the standalone CLI uses.
+
+**Constraints:**
+- Plugin entry point MUST NOT require Rooibos or `ratatui_ruby` (per ADR-0014). TUI loading is gated to the standalone binary.
+- Bare `bundle contribute` runs the default verb (TBD per OPEN_QUESTIONS Q3a: `scan` or `list all`).
+- `bundle contribute <verb>` mirrors `gem-contribute <verb>`.
+
+**Acceptance:**
+- [ ] `bundle plugin install gem-contribute` works against the local gem
+- [ ] `bundle contribute` produces the default summary
+- [ ] `bundle contribute fix sidekiq/123` runs the fix verb
+- [ ] Smoke test verifies plugin registration without booting the TUI
+
+**Issue:** [#38](https://github.com/cdhagmann/gem-contribute/issues/38) — Bundler plugin: `bundle contribute` entry point
+
+## RubyGems plugin (`gem contribute`)
+
+A `rubygems_plugin.rb` entry point registers a `Gem::Command` subclass per RubyGems convention. Same dispatch table.
+
+**Constraints:**
+- Same TUI-load gating as the Bundler plugin.
+- Same default-verb behavior as the Bundler plugin.
+
+**Acceptance:**
+- [ ] `gem install gem-contribute` registers the `Gem::Command`
+- [ ] `gem contribute --help` lists the same verbs as `gem-contribute --help`
+- [ ] `gem contribute fix sidekiq/123` runs the fix verb
+- [ ] Smoke test verifies plugin registration without booting the TUI
+
+**Issue:** [#39](https://github.com/cdhagmann/gem-contribute/issues/39) — RubyGems plugin: `gem contribute` Gem::Command
+
+## Multi-host adapters
+
+ADR-0011's HostAdapter architecture is the bet that pays off here. Each host is its own adapter implementing the same interface (`fork`, `comment`, `pull_request_url`, etc.).
+
+- [ ] [#8](https://github.com/cdhagmann/gem-contribute/issues/8) — GitLab adapter
+- [ ] [#50](https://github.com/cdhagmann/gem-contribute/issues/50) — gem.coop-exclusive gems via Resolver fallback to the gem.coop API
+
+## Other v1.x candidates
+
+- [ ] 🌱 [#3](https://github.com/cdhagmann/gem-contribute/issues/3) — `gem-contribute open <gem>` to open the repo in the browser
+- [ ] [#47](https://github.com/cdhagmann/gem-contribute/issues/47) — Meta-PR: use `gem-contribute` against a real downstream
+- [ ] [#49](https://github.com/cdhagmann/gem-contribute/issues/49) — `gem-contribute rate <gem|owner/repo>` — Good First Repo scoring (needs an ADR before implementation; the scoring rubric is its own design problem)
+
+---
+
+# v2.0 — Rooibos TUI
+
+**Umbrella issue:** [#2 — Implement Rooibos TUI on top of the v0.1 CLI](https://github.com/cdhagmann/gem-contribute/issues/2). The major work. Per design.md and ADR-0013. v2.0 because bare-invocation behavior changes (`gem-contribute` with no args goes from "print USAGE" to "launch TUI"); existing pipe-into-CLI scripts would otherwise break.
 
 **Pre-work (Q7 verification):**
 - [ ] Confirm Rooibos's current published version on rubygems.org
@@ -130,7 +219,7 @@ Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51). Move CLI 
 - `ContributingViewer` — rendered markdown (ADR-0007); also surfaces the upstream PR template per [#13](https://github.com/cdhagmann/gem-contribute/issues/13)
 - `AuthOverlay` — device-flow prompt that fires on `:auth_required`
 
-(World map fragment is post-v1; framework choice locks in now per ADR-0013.)
+(The world map fragment stays post-v2.0 — awaits adoption to make the data interesting. Framework choice locked in now per ADR-0013.)
 
 **Wiring:**
 - [ ] `gem-contribute` (no args, with a `Gemfile.lock` in cwd) launches the TUI. This is the entry-point change in `cli.rb`.
@@ -160,90 +249,15 @@ Open in [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51). Move CLI 
 
 ---
 
-## Phase 4 — Bundler plugin (`bundle contribute`)
+# Out of scope (any version)
 
-A `plugins.rb` entry point at the root of the gem registers a Bundler plugin command per Bundler convention. Delegates to the same dispatch table the standalone CLI uses.
-
-**Constraints:**
-- Plugin entry point MUST NOT require Rooibos or `ratatui_ruby` (per ADR-0014). TUI loading is gated to the standalone binary.
-- Bare `bundle contribute` runs the default verb (TBD per OPEN_QUESTIONS Q3a: `scan` or `list all`).
-- `bundle contribute <verb>` mirrors `gem-contribute <verb>`.
-
-**Acceptance:**
-- [ ] `bundle plugin install gem-contribute` works against the local gem
-- [ ] `bundle contribute` produces the default summary
-- [ ] `bundle contribute fix sidekiq/123` runs the fix verb
-- [ ] Smoke test verifies plugin registration without booting the TUI
-
-**Issue:** [#38](https://github.com/cdhagmann/gem-contribute/issues/38) — Bundler plugin: `bundle contribute` entry point
-
----
-
-## Phase 5 — RubyGems plugin (`gem contribute`)
-
-A `rubygems_plugin.rb` entry point registers a `Gem::Command` subclass per RubyGems convention. Same dispatch table.
-
-**Constraints:**
-- Same TUI-load gating as Phase 4.
-- Same default-verb behavior as Phase 4.
-
-**Acceptance:**
-- [ ] `gem install gem-contribute` registers the `Gem::Command`
-- [ ] `gem contribute --help` lists the same verbs as `gem-contribute --help`
-- [ ] `gem contribute fix sidekiq/123` runs the fix verb
-- [ ] Smoke test verifies plugin registration without booting the TUI
-
-**Issue:** [#39](https://github.com/cdhagmann/gem-contribute/issues/39) — RubyGems plugin: `gem contribute` Gem::Command
-
----
-
-## Phase 6 — Polish, release infrastructure, v1.0
-
-Everything required to call it 1.0 and not 0.x.
-
-**Pre-existing user-facing issues that fold into this phase:**
-- [ ] 🌱 [#1 — Add `preferred_labels` config so non-canonical good-first-issue labels are caught](https://github.com/cdhagmann/gem-contribute/issues/1)
-- [ ] 🌱 [#3 — Add `gem-contribute open <gem>` to open the repo in the browser](https://github.com/cdhagmann/gem-contribute/issues/3)
-- [ ] 🌱 [#9 — Add `--label LABEL` flag to scan and issues for one-off overrides](https://github.com/cdhagmann/gem-contribute/issues/9) (related to #1)
-- [ ] 🌱 [#10 — Friendlier message when `fix` runs against a repo you own](https://github.com/cdhagmann/gem-contribute/issues/10)
-
-**Release infrastructure:**
-- [ ] 🌱 [#40](https://github.com/cdhagmann/gem-contribute/issues/40) — Add CHANGELOG.md
-- [ ] 🌱 [#41](https://github.com/cdhagmann/gem-contribute/issues/41) — Add CONTRIBUTING.md
-- [ ] [#42](https://github.com/cdhagmann/gem-contribute/issues/42) — Add MAINTAINER.md (release process, OAuth App, plugin verification)
-- [ ] OAuth App: stay on personal-account App for v1.0 (per Q13); migrate when rate limits bite
-- [ ] [#43](https://github.com/cdhagmann/gem-contribute/issues/43) — CI workflow (`.github/workflows/ci.yml`): rubocop + rspec; gated integration tests; plugin install smoke (basic rubocop + rspec already landed via [PR #21](https://github.com/cdhagmann/gem-contribute/pull/21) / [#7](https://github.com/cdhagmann/gem-contribute/issues/7); gated integration tests and plugin smoke still pending)
-- [x] [#44](https://github.com/cdhagmann/gem-contribute/issues/44) — Release workflow (`.github/workflows/release.yml`) with **Trusted Publishing (OIDC)** (will go live with the 0.4 release)
-- [ ] 🌱 [#45](https://github.com/cdhagmann/gem-contribute/issues/45) — Archive workshop docs to `docs/archive/`
-- [ ] [#46](https://github.com/cdhagmann/gem-contribute/issues/46) — README rewrite for v1 audience
-- [ ] Verify `bundle plugin install` and `gem install` from a clean machine (covered by CI smoke test in #43)
-- [ ] [#47](https://github.com/cdhagmann/gem-contribute/issues/47) — Meta-PR: use `gem-contribute` against a real downstream
-- [ ] Tag `v1.0.0`, push to rubygems
-
----
-
-## Sequencing logic
-
-- **Phase 0 → 1 → 2 are strictly ordered.** Each unblocks the next.
-- **Phase 3, 4, 5 can in principle parallelize** once Phases 1–2 land. In practice Phase 3 (TUI) is the biggest piece and probably ships first; the plugin shims (Phases 4–5) are small once the dispatch table is the single source of truth.
-- **Phase 6 happens after** all of 3/4/5 work end-to-end.
-
-If we're behind: Phase 3 is the load-bearing one for "v1 worth releasing." Phases 4–5 can slip to v1.1 if needed (they unlock the better-discoverability story but don't change capability). Phase 6 cannot slip.
-
----
-
-## Out of scope at v1.0
-
-(Confirmed via OPEN_QUESTIONS Q10.)
-
-- Multi-host adapters — v1.x. GitLab tracked at [#8](https://github.com/cdhagmann/gem-contribute/issues/8); Codeberg/sourcehut not yet ticketed.
-- gem.coop-exclusive gems — v1.x. Mirrored gems work today; dedicated-namespace gems need a Resolver fallback to the gem.coop API. Tracked at [#50](https://github.com/cdhagmann/gem-contribute/issues/50).
-- World-map TUI fragment — post-v1, awaits adoption. Tracked indirectly via [#5](https://github.com/cdhagmann/gem-contribute/issues/5)'s acceptance criteria (which also owns the `KICKED_THE_TIRES.yml` data source). [needs dedicated issue when ready to build]
-- Private repos / `repo` OAuth scope — post-v1, no issue
-- PR creation from inside the TUI — design choice, browser-based stays (ADR-0011)
-- AI-anything (ADR-0007)
-- Label normalization (ADR-0005)
-- CONTRIBUTING parsing (ADR-0007)
+- Codeberg/sourcehut adapters — no current ticket, post-v1.x.
+- World-map TUI fragment — post-v2.0, awaits adoption. Tracked indirectly via [#5](https://github.com/cdhagmann/gem-contribute/issues/5)'s acceptance criteria (which also owns the `KICKED_THE_TIRES.yml` data source).
+- Private repos / `repo` OAuth scope — post-v1, no issue.
+- PR creation from inside the TUI — design choice, browser-based stays (ADR-0011).
+- AI-anything (ADR-0007).
+- Label normalization (ADR-0005).
+- CONTRIBUTING parsing (ADR-0007).
 
 🌱 [#5](https://github.com/cdhagmann/gem-contribute/issues/5) itself stays open indefinitely as a sandbox for new contributors to practice the `fix` → `submit` loop.
 
@@ -251,16 +265,18 @@ If we're behind: Phase 3 is the load-bearing one for "v1 worth releasing." Phase
 
 ## Issue tracking
 
-All roadmap work is tracked on the issue tracker. Filter by `phase:N` label to see a phase's work, e.g. [phase:1](https://github.com/cdhagmann/gem-contribute/labels/phase%3A1).
+All roadmap work is tracked on the issue tracker. Filter by label:
+- `phase:1`, `phase:2`, `phase:6` for v1.0 work
+- `v1.x` for plugin / multi-host / polish-extension work
+- `v2.0` for Rooibos TUI work
 
-| Phase | Issue range | Notes |
+| Bucket | Issues | Notes |
 |---|---|---|
-| 0 | #23, #24 | Two doc sweeps |
-| 1 | #25–#28 | Service layer (ADR-0012) |
-| 2 | #29–#31 | CLI output pipeline |
-| 3 | umbrella #2 + sub-issues #32–#37, plus #13 | Five fragments + launch wiring |
-| 4 | #38 | Bundler plugin |
-| 5 | #39 | RubyGems plugin |
-| 6 | #40–#47, plus #1, #3, #9, #10 | Release infra + pre-existing polish |
+| Phase 0 (DONE) | #23, #24 | Two doc sweeps |
+| Phase 1 (DONE) | #25–#28 | Service layer (ADR-0012) |
+| Phase 2 (in flight) | #29–#31 | CLI output pipeline |
+| Phase 6 (v1.0 polish + release) | #1, #9, #10, #40–#46, #54 | Release infra + papercut polish |
+| v1.x | #3, #8, #38, #39, #47, #49, #50 | Plugins, multi-host, extensions |
+| v2.0 | #2 (umbrella), #13, #32–#37 | Rooibos TUI |
 
-Out-of-scope items don't get phase labels. [#5](https://github.com/cdhagmann/gem-contribute/issues/5) (sandbox) and [#8](https://github.com/cdhagmann/gem-contribute/issues/8) (GitLab adapter, v1.x) live without phase labels.
+Out-of-scope items don't get version labels. [#5](https://github.com/cdhagmann/gem-contribute/issues/5) (sandbox) stays without phase or version labels.

--- a/docs/adr/0014-ship-bundler-and-rubygems-plugins.md
+++ b/docs/adr/0014-ship-bundler-and-rubygems-plugins.md
@@ -1,8 +1,9 @@
 # ADR 0014: Ship Bundler and RubyGems plugins as v1 interfaces
 
-**Status:** Accepted
+**Status:** Accepted (amended by [ADR-0015](0015-descope-v1-cli-only.md) on shipping order)
 **Date:** 2026-05-03
 **Amends:** [ADR-0006](0006-standalone-gem-not-plugin.md), [ADR-0012](0012-output-free-service-objects-three-interface-architecture.md)
+**Amended by:** [ADR-0015](0015-descope-v1-cli-only.md) — plugin shims defer from v1.0 to v1.x; the "plugins live inside `gem-contribute`, not as separate gems" architectural decision in this ADR is preserved unchanged
 
 ## Context
 

--- a/docs/adr/0015-descope-v1-cli-only.md
+++ b/docs/adr/0015-descope-v1-cli-only.md
@@ -1,0 +1,95 @@
+# ADR 0015: Descope v1.0 to standalone CLI; plugins to v1.x; TUI to v2.0
+
+**Status:** Accepted
+**Date:** 2026-05-04
+**Amends:** [ADR-0014](0014-ship-bundler-and-rubygems-plugins.md)
+
+## Context
+
+The current v1.0 plan (ROADMAP as of 2026-05-04, before this ADR) ships three entry points:
+
+1. Standalone CLI binary (`gem-contribute`) — bare invocation launches the Rooibos TUI
+2. Bundler plugin (`bundle contribute`) — CLI-only
+3. RubyGems plugin (`gem contribute`) — CLI-only
+
+[ADR-0014](0014-ship-bundler-and-rubygems-plugins.md) (2026-05-03) committed to that scope. It amended [ADR-0006](0006-standalone-gem-not-plugin.md)'s "no Bundler plugin" decision and [ADR-0012](0012-output-free-service-objects-three-interface-architecture.md)'s "three separate gems" sketch. The reasoning was sound: workshop is over, the plugin shims are small, one gem with three entry points is cheap to maintain.
+
+What ADR-0014 didn't examine is **shipping order**. It treated all three entry points as v1.0 prerequisites because that was the existing v1 frame. Phases 3 (TUI), 4 (Bundler plugin), and 5 (RubyGems plugin) on the ROADMAP all sit between "service layer done" and "v1.0 ships."
+
+Two facts shift the calculus on shipping order:
+
+1. **Phase 3 (TUI) is the single biggest piece of remaining work.** Five fragments, an auto-launch wiring change, snapshot tests, and a Rooibos pin verification. Realistically months of work for a solo project that doesn't have it started. Holding 1.0 behind it means the gem stays unpublished while design assumptions about TUI fragments accumulate without real-user contact.
+
+2. **Phases 4–5 (plugins) are thin shims.** Their architecture is already locked in by ADR-0014 (single gem, dispatch table is the source of truth). The remaining design questions — default verb for `bundle contribute` (per OPEN_QUESTIONS Q3a), error/output styling, where the plugin install smoke test sits — are exactly the kind of UX questions that benefit from "what do real CLI users actually do." Building plugin UX on assumptions before any rubygems user exists is a worse trade than shipping the CLI, watching usage, then committing to plugin shape with information.
+
+The Blue Ridge Ruby workshop concluded 2026-05-02 (the same context that drove [ADR-0013](0013-revert-to-rooibos.md) and [ADR-0014](0014-ship-bundler-and-rubygems-plugins.md)). Workshop-era decisions about scope are revisitable.
+
+## Decision
+
+**v1.0 ships the standalone CLI alone.** Three entry points become a release sequence rather than a launch bundle:
+
+- **v1.0** — `gem-contribute` standalone CLI on rubygems.org. Output-free service layer (Phase 1, done), CLI output abstraction (Phase 2, in flight), release infrastructure, README rewrite, and the polish issues that are real papercuts on the core flow.
+
+- **v1.x** — Bundler plugin (`bundle contribute`) and RubyGems plugin (`gem contribute`) ship as point releases. Multi-host adapters (GitLab — issue [#8](https://github.com/cdhagmann/gem-contribute/issues/8); gem.coop — issue [#50](https://github.com/cdhagmann/gem-contribute/issues/50)) also live in this lane. Each of these can be its own minor (1.1, 1.2, …) or rolled together; sequencing is a runtime call.
+
+- **v2.0** — Rooibos TUI. Bare `gem-contribute` invocation switches from "print USAGE" to "launch TUI" at 2.0. Five fragments per design.md, the world-map fragment, the auto-launch wiring change. Treated as a major version because bare-invocation behavior is a user-visible behavior change (existing scripts that pipe `gem-contribute` would now block on a TUI startup).
+
+The "single gem with three entry points" architecture decision in ADR-0014 is **preserved**. Plugins still ship inside the `gem-contribute` gem; they don't become separate gems. What changes is *when*, not *what*.
+
+## Reasoning
+
+**Real users beat planned roadmap.** Every month before the gem hits rubygems.org is a month of design assumptions about TUI fragments, plugin defaults, and edge cases that no real user has stress-tested. Shipping a CLI 1.0 in days converts that uncertainty into evidence. The TUI design that ships in 2.0 will be informed by what real users actually do; the plugin shape that ships in 1.x will be informed by what CLI patterns turn out to matter.
+
+**ADR-0014's architectural decision survives intact.** The v1 commitment to "plugins live inside gem-contribute, not as separate gems" was the load-bearing call. Whether they ship at v1.0, v1.1, or v1.2 doesn't affect the architecture — the dispatch table is already the single source of truth, the plugin entry-point files (`plugins.rb`, `rubygems_plugin.rb`) are tiny additions when the time comes. Deferring is purely sequencing.
+
+**TUI as 2.0 reflects the actual size of the change.** A TUI is not a polish layer; it's a different interaction model. Treating it as a major-version event matches the user-visible weight: bare-invocation behavior changes, dependencies grow (`rooibos`, `ratatui_ruby` move from optional to default), terminal-capability assumptions enter the install path. SemVer-clean.
+
+**Plugins as 1.x because the CLI surface stays compatible.** `bundle contribute` and `gem contribute` are additive — they expose the existing CLI verbs through new entry points. No breaking change for users on `gem-contribute` directly. SemVer-minor fits.
+
+**Repo adapters as 1.x because they extend reach without changing existing behavior.** GitLab and gem.coop adapters expand which gems are scannable; they don't change how scanning works for github.com gems. SemVer-minor fits.
+
+## Alternatives considered
+
+- **Keep ADR-0014's bundle: ship CLI + plugins + TUI all at v1.0.** Rejected: described in detail above. The TUI alone holds 1.0 for an indeterminate period. Plugins built without real-user data lock in UX assumptions early.
+
+- **Ship CLI + plugins at v1.0; defer TUI to v2.0.** Tempting middle ground. Rejected: still puts plugin-UX decisions before rubygems publication, just with a slightly faster timeline. Plugins are a small enough chunk that the lockstep with CLI 1.0 doesn't earn the wait.
+
+- **Ship CLI + TUI at v1.0; defer plugins to v1.x.** Rejected: TUI is the bottleneck regardless. If TUI is in v1.0, plugins-with-it doesn't materially extend the timeline, but TUI alone does.
+
+- **Drop plugins entirely; ADR-0014 supersession instead of amendment.** Rejected: ADR-0014's reasoning for plugins (discoverability via `bundle X` / `gem X`) is still correct. The argument is *when* not *whether*. Supersession would re-litigate a settled question.
+
+- **Drop TUI entirely; remove from roadmap.** Rejected: the TUI is the differentiated UX of the gem (per design.md and the workshop framing). Dropping it loses the project's "render the data the maintainer wrote it" narrative, which is hard to do in CLI alone (CONTRIBUTING viewer especially). 2.0 preserves the commitment with realistic timing.
+
+## Consequences
+
+**On the v1 statement at the top of `docs/ROADMAP.md`** (line 3-9 currently): rewrite. The "single gem, three entry points" framing moves to 2.0; v1.0 is a CLI-on-rubygems release.
+
+**On phase numbering and labels:**
+
+- `phase:1` (DONE), `phase:2` (in flight), `phase:6` (renumbered to **Phase 3** in the new ROADMAP since it's the third remaining v1.0 phase) make up v1.0.
+- `phase:3` (TUI) issues — [#2](https://github.com/cdhagmann/gem-contribute/issues/2), [#13](https://github.com/cdhagmann/gem-contribute/issues/13), [#32](https://github.com/cdhagmann/gem-contribute/issues/32) through [#37](https://github.com/cdhagmann/gem-contribute/issues/37) — relabel to `v2.0`.
+- `phase:4` (Bundler plugin) issue [#38](https://github.com/cdhagmann/gem-contribute/issues/38) and `phase:5` (RubyGems plugin) issue [#39](https://github.com/cdhagmann/gem-contribute/issues/39) — relabel to `v1.x`.
+- Existing v1.x candidates without phase labels — [#8](https://github.com/cdhagmann/gem-contribute/issues/8), [#50](https://github.com/cdhagmann/gem-contribute/issues/50) — also gain `v1.x`.
+
+**On `ADR-0014`:** add an "Amended by ADR-0015" header note. The body of ADR-0014 stays valid — the architectural commitment to "single gem, plugins-not-separate-gems" is unchanged. Only the implicit "all three entry points at v1.0" assumption is amended.
+
+**On `README.md` (`#46` rewrite):** the v1 audience messaging frames the gem as a CLI tool. TUI gets a "coming in v2" mention; plugins get a "coming in v1.x." Avoids over-promising what 1.0 actually delivers.
+
+**On `OPEN_QUESTIONS.md`:** Q3a (default verb for `bundle contribute`) becomes a v1.x decision. Doesn't block 1.0.
+
+**On `MAINTAINER.md`:** the per-release checklist applies identically to 1.x point releases as to 1.0. No changes needed.
+
+**On the existing PR queue:** [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51) (Phase 2) and [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55) (release infra + 0.3.1) are both unaffected — their content is in v1.0 either way. No re-scoping needed for in-flight PRs.
+
+**On polish issues:**
+
+- [#1](https://github.com/cdhagmann/gem-contribute/issues/1), [#9](https://github.com/cdhagmann/gem-contribute/issues/9), [#10](https://github.com/cdhagmann/gem-contribute/issues/9), [#46](https://github.com/cdhagmann/gem-contribute/issues/46), [#54](https://github.com/cdhagmann/gem-contribute/issues/54) — kept in v1.0. Real papercuts on the core flow.
+- [#3](https://github.com/cdhagmann/gem-contribute/issues/3) (open verb), [#47](https://github.com/cdhagmann/gem-contribute/issues/47) (meta-PR dogfooding) — pushed to v1.x. Nice to have, not papercuts.
+
+## What this *doesn't* change
+
+- **[ADR-0014](0014-ship-bundler-and-rubygems-plugins.md) architectural decision.** Plugins still live inside `gem-contribute`, not as separate gems. The dispatch table stays the source of truth. Plugin entry points stay TUI-free.
+- **[ADR-0013](0013-revert-to-rooibos.md) framework choice.** Rooibos is still the TUI framework when TUI ships at 2.0.
+- **[ADR-0012](0012-output-free-service-objects-three-interface-architecture.md) service-layer contract.** Output-free, `Result`-returning operations are what makes the CLI / plugin / TUI split work. The contract is identical whether plugins ship at 1.0 or 1.x.
+- **[ADR-0011](0011-host-adapter-owns-host-verbs.md) host adapter design.** Multi-host adapters (GitLab, gem.coop) ship at v1.x using the same architecture.
+- **The product thesis.** "Find contributable issues in the gems your project depends on" is unchanged. v1.0 just delivers it in CLI form first.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,8 @@ Format: [Michael Nygard's template](https://github.com/joelparkerhenderson/archi
 - [0011 — HostAdapter owns host verbs; Operations compose them; CLI verbs compose Operations](0011-host-adapter-owns-host-verbs.md)
 - [0012 — Output-free service objects, dry-monads Result contract, three-interface architecture](0012-output-free-service-objects-three-interface-architecture.md) — packaging amended by 0014; service-layer contract stands
 - [0013 — Revert TUI framework to Rooibos](0013-revert-to-rooibos.md) — supersedes 0010, restores 0008's substance
-- [0014 — Ship Bundler and RubyGems plugins as v1 interfaces](0014-ship-bundler-and-rubygems-plugins.md) — amends 0006 and 0012
+- [0014 — Ship Bundler and RubyGems plugins as v1 interfaces](0014-ship-bundler-and-rubygems-plugins.md) — amends 0006 and 0012; shipping order amended by 0015
+- [0015 — Descope v1.0 to standalone CLI; plugins to v1.x; TUI to v2.0](0015-descope-v1-cli-only.md) — amends 0014
 
 ## When to add an ADR
 


### PR DESCRIPTION
## Summary

Records [ADR-0015](docs/adr/0015-descope-v1-cli-only.md): v1.0 ships the standalone CLI alone; Bundler and RubyGems plugins ship at v1.x point releases; the Rooibos TUI ships at v2.0. ADR-0014's architectural decision (single gem, plugins-not-separate-gems) is preserved — only the *timing* is amended.

ROADMAP rewritten around the new shape: v1.0 phase ordering is now **1 → 2 → 6** (Phase 6 retained as the label for the polish/release work to keep historical references stable). v1.x section consolidates plugin shims, multi-host adapters, and polish-extension issues. v2.0 section contains the full TUI plan from the old Phase 3.

README rewritten ([#46](https://github.com/cdhagmann/gem-contribute/issues/46)) so the public-facing messaging matches: Status section describes the v1.0 / v1.x / v2.0 trajectory, workshop framing removed, label-targeted contributor pointers added.

| Commit | What |
|---|---|
| `2a6c02b` | ADR-0015 + ADR-0014 amendment + ROADMAP restructure |
| `776b1bc` | Mark Phase 2 DONE (PR #51 already merged) |
| `1ea57a8` | README rewrite for v1 audience (closes #46) |

Issues retagged via `gh`:

| Was | Now | Issues |
|---|---|---|
| `phase:3` | `v2.0` | #2, #13, #32–#37 |
| `phase:4` | `v1.x` | #38 |
| `phase:5` | `v1.x` | #39 |
| `phase:6` | `v1.x` | #3, #47 (moved out of v1.0 polish) |
| (none) | `v1.x` added | #8, #50, #49 |

Polish staying in v1.0 (`phase:6`): #1, #9, #10, #40, #41, #42, #43, #45, #54.

## Linked issue / ADR

Closes [#46](https://github.com/cdhagmann/gem-contribute/issues/46) (README rewrite). ADR-0015 created; ADR-0014 amended (header note + index update).

## Working agreement

- [x] Single concern — v1.0 scope decision (ADR-0015) and the docs/labels/README that propagate it
- [x] `bin/rubocop` and `bin/rspec` pass locally — no Ruby touched
- [x] New behavior has a test — N/A; pure docs and label change
- [x] Async work goes through Rooibos Commands — N/A

## Test plan

- [x] All ADR cross-references resolve (ADR README index, ADR-0014's "amended by" note, ROADMAP's "see ADR-0015" pointer, README's ADR-0015 link)
- [x] Issue label distribution verified by query: `phase:6` has the v1.0 polish set; `v1.x` has plugin/multi-host/extension issues; `v2.0` has the TUI fragment set
- [x] README renders cleanly on GitHub (`bin/markdown` not configured, but plain markdown is straightforward)
- [x] Phase numbering in ROADMAP narrative (1, 2, 6) matches the labels still on issues — no renumbering of `phase:6` since that would break PR-description references

## Notes for reviewer

- **Why amend ADR-0014 instead of supersede?** The architectural call (single gem, dispatch table, plugin entry points TUI-free) is still correct. Only the launch ordering is changing. Supersession would re-litigate the architecture; amendment captures "same decision, deferred timing."
- **Why TUI as 2.0 (not 1.x)?** The bare-invocation behavior of `gem-contribute` changes when the TUI auto-launches — existing scripts that pipe the no-arg CLI would now block on a TUI startup. SemVer-clean.
- **Why plugins as 1.x (not 2.0)?** Additive only — the existing CLI surface stays the same. SemVer-minor fits.
- **Phase 2 was already DONE.** PR #51 merged 2026-05-04; the original descope commit on this branch still listed it as in flight. Fixed in `776b1bc`.
- **README scope.** I narrowed the edit to the two sections that were actually stale (Status + Contributing) plus a label-pointer addition. The Usage/Configuration/Design sections describe the current CLI surface accurately and didn't need touching. When plugins land at v1.x, a "Quick start with plugins" section is the natural addition then.
- **In-flight PRs unaffected.** [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55) (release infra + 0.3.1) is v1.0 work either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
