### PR TITLE
fix(ci): pr-template-check YAML syntax error

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -64,9 +64,12 @@ jobs:
           if [ ${#missing[@]} -eq 0 ] && [ "$prose_chars" -ge 40 ]; then
             echo "PR body looks good."
             if [ -n "$prior_id" ]; then
+              {
+                echo "$MARKER"
+                echo "✅ PR template check passed. Thanks for filling out the template."
+              } > /tmp/comment.md
               gh api -X PATCH "repos/$REPO/issues/comments/$prior_id" \
-                -f body="$MARKER
-✅ PR template check passed. Thanks for filling out the template."
+                -F body=@/tmp/comment.md
             fi
             exit 0
           fi


### PR DESCRIPTION
## Summary

Fixes the `pr-template-check` workflow's YAML syntax error introduced in [PR #53](https://github.com/cdhagmann/gem-contribute/pull/53). Every PR has been showing "Invalid workflow file" since #53 merged because the workflow file itself fails to parse.

## Linked issue / ADR

No issue. Bug introduced by my own [PR #53](https://github.com/cdhagmann/gem-contribute/pull/53). No ADR — straight bug fix.

## Working agreement

- [x] Single concern — one workflow YAML fix
- [x] `bin/rubocop` and `bin/rspec` pass locally — no Ruby touched
- [x] New behavior has a test — `python3 -c "import yaml; yaml.safe_load(...)"` confirms parse; the workflow's actual behavior is verified by the next PR's check run
- [x] Async work goes through Rooibos Commands — N/A

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-template-check.yml').read())"` — clean parse
- [ ] First real run: this PR's own pr-template-check should pass (it's against the fixed workflow on the head branch). Subsequent PRs will also pick up the fix once this lands

## Notes for reviewer

**Root cause:** lines 67–69 of the original workflow had a bash double-quoted string spanning a YAML line break:

```yaml
              gh api -X PATCH "repos/$REPO/issues/comments/$prior_id" \
                -f body="$MARKER
✅ PR template check passed. Thanks for filling out the template."
```

The `✅` line had no leading whitespace because bash quoting preserves newlines verbatim — but YAML's `|` block-literal mode requires every continuation line to be indented at least as far as the first. Line 69 dedented to column 1, YAML closed the block prematurely, and `✅` parsed as an invalid top-level scalar.

**Fix:** the failure-comment path (lines 74–96 in the original) already uses a `{ echo ...; } > /tmp/comment.md` pattern with `-F body=@/tmp/comment.md`. Made the success-comment path use the same shape. No multi-line embedded strings in YAML now; the two paths are consistent.

**Side effect:** this unblocks [PR #56](https://github.com/cdhagmann/gem-contribute/pull/56)'s template check, which has been failing only because of this YAML error (the PR body itself is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
