### PR TITLE
fix: friendlier message when fix runs against a repo you own

### DIFF
--- a/lib/gem_contribute/cli/fork.rb
+++ b/lib/gem_contribute/cli/fork.rb
@@ -107,7 +107,9 @@ module GemContribute
       end
 
       def fork_status_line(info, project)
-        if info.reused
+        if info.owned_upstream
+          "  You own #{project.owner}/#{project.repo} upstream. Cloning directly; no fork needed."
+        elsif info.reused
           "  Reusing existing fork at #{info.viewer}/#{project.repo}."
         else
           "  Forked → #{info.viewer}/#{project.repo}."

--- a/lib/gem_contribute/host_adapter.rb
+++ b/lib/gem_contribute/host_adapter.rb
@@ -30,11 +30,12 @@ module GemContribute
   # See ADR-0001 for the JIT auth contract.
   class HostAdapter
     # Result of a successful `fork(project)`.
-    # - clone_url:  HTTPS URL suitable for `git clone`.
-    # - fork_url:   human-readable web URL of the fork (used in summaries).
-    # - viewer:     the authenticated user's login (and the fork's owner).
-    # - reused:     true if the fork already existed; false if just created.
-    ForkResult = Data.define(:clone_url, :fork_url, :viewer, :reused)
+    # - clone_url:      HTTPS URL suitable for `git clone`.
+    # - fork_url:       human-readable web URL of the fork (used in summaries).
+    # - viewer:         the authenticated user's login (and the fork's owner).
+    # - reused:         true if the fork already existed; false if just created.
+    # - owned_upstream: true when viewer == project.owner (viewer IS the upstream).
+    ForkResult = Data.define(:clone_url, :fork_url, :viewer, :reused, :owned_upstream)
 
     def issues(_project, labels: nil)
       raise NotImplementedError

--- a/lib/gem_contribute/host_adapters/github_adapter.rb
+++ b/lib/gem_contribute/host_adapters/github_adapter.rb
@@ -97,6 +97,7 @@ module GemContribute
 
         ensure_known_host!(project)
         viewer = viewer_login
+        return existing_fork_result(viewer, project, owned_upstream: true) if viewer == project.owner
         return existing_fork_result(viewer, project) if fork_exists?(viewer, project.repo)
 
         body = post_json("/repos/#{project.owner}/#{project.repo}/forks")
@@ -173,12 +174,13 @@ module GemContribute
 
       private
 
-      def existing_fork_result(viewer, project)
+      def existing_fork_result(viewer, project, owned_upstream: false)
         ForkResult.new(
           clone_url: clone_url(viewer, project.repo),
           fork_url: repo_url(viewer, project.repo),
           viewer: viewer,
-          reused: true
+          reused: true,
+          owned_upstream: owned_upstream
         )
       end
 
@@ -187,7 +189,8 @@ module GemContribute
           clone_url: body.fetch("clone_url", clone_url(viewer, project.repo)),
           fork_url: body.fetch("html_url", repo_url(viewer, project.repo)),
           viewer: viewer,
-          reused: false
+          reused: false,
+          owned_upstream: false
         )
       end
 

--- a/lib/gem_contribute/operations/fork.rb
+++ b/lib/gem_contribute/operations/fork.rb
@@ -12,7 +12,7 @@ module GemContribute
     class Fork
       include Dry::Monads[:result]
 
-      Result = Data.define(:clone_url, :fork_url, :upstream_url, :viewer, :reused)
+      Result = Data.define(:clone_url, :fork_url, :upstream_url, :viewer, :reused, :owned_upstream)
 
       def call(adapter:, project:)
         fork = adapter.fork(project)
@@ -22,7 +22,8 @@ module GemContribute
             fork_url: fork.fork_url,
             upstream_url: adapter.repo_url(project.owner, project.repo),
             viewer: fork.viewer,
-            reused: fork.reused
+            reused: fork.reused,
+            owned_upstream: fork.owned_upstream
           )
         )
       rescue GemContribute::AuthRequired

--- a/spec/gem_contribute/cli/fix_spec.rb
+++ b/spec/gem_contribute/cli/fix_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe GemContribute::CLI::Fix do
       clone_url: "https://github.com/alice/sidekiq.git",
       fork_url: "https://github.com/alice/sidekiq",
       upstream_url: "https://github.com/sidekiq/sidekiq",
-      viewer: "alice", reused: false
+      viewer: "alice", reused: false, owned_upstream: false
     )
   end
   let(:clone_data) { GemContribute::Operations::Clone::Result.new(path: target, reused: false) }

--- a/spec/gem_contribute/cli/fork_spec.rb
+++ b/spec/gem_contribute/cli/fork_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GemContribute::CLI::Fork do
       clone_url: "https://github.com/alice/sidekiq.git",
       fork_url: "https://github.com/alice/sidekiq",
       upstream_url: "https://github.com/sidekiq/sidekiq",
-      viewer: "alice", reused: false
+      viewer: "alice", reused: false, owned_upstream: false
     )
   end
   let(:clone_info) { GemContribute::Operations::Clone::Result.new(path: target_path, reused: false) }
@@ -199,6 +199,16 @@ RSpec.describe GemContribute::CLI::Fork do
 
       expect(stdout.string).to include("Reusing existing fork at alice/sidekiq")
       expect(stdout.string).to include("Reusing existing clone at #{target_path}")
+    end
+
+    it "prints owned-upstream message when viewer is the project owner" do
+      owned_fork = fork_info.with(reused: true, owned_upstream: true)
+      allow(fork_op).to receive(:call).and_return(Success(owned_fork))
+      allow(clone_op).to receive(:call).and_return(Success(clone_info))
+
+      cli.bootstrap(adapter, project)
+
+      expect(stdout.string).to include("You own sidekiq/sidekiq upstream. Cloning directly; no fork needed.")
     end
   end
 end

--- a/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
+++ b/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
@@ -106,8 +106,27 @@ RSpec.describe GemContribute::HostAdapters::GitHubAdapter do
           clone_url: "https://github.com/alice/sidekiq.git",
           fork_url: "https://github.com/alice/sidekiq",
           viewer: "alice",
-          reused: true
+          reused: true,
+          owned_upstream: false
         )
+        expect(WebMock).not_to have_requested(:post, %r{/forks})
+      end
+
+      it "returns owned_upstream: true and skips fork_exists? check when viewer is the project owner" do
+        owned_project = GemContribute::Project.new(
+          gem_name: "gem-contribute", host: "github.com",
+          owner: "alice", repo: "gem-contribute", metadata: {}
+        )
+
+        result = adapter.fork(owned_project)
+
+        expect(result).to have_attributes(
+          clone_url: "https://github.com/alice/gem-contribute.git",
+          viewer: "alice",
+          reused: true,
+          owned_upstream: true
+        )
+        expect(WebMock).not_to have_requested(:get, %r{/repos/alice/gem-contribute})
         expect(WebMock).not_to have_requested(:post, %r{/forks})
       end
 

--- a/spec/gem_contribute/operations/fix_pipeline_spec.rb
+++ b/spec/gem_contribute/operations/fix_pipeline_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GemContribute::Operations::FixPipeline do
       clone_url: "https://github.com/alice/sidekiq.git",
       fork_url: "https://github.com/alice/sidekiq",
       upstream_url: "https://github.com/sidekiq/sidekiq",
-      viewer: "alice", reused: false
+      viewer: "alice", reused: false, owned_upstream: false
     )
   end
   let(:clone_result) do

--- a/spec/gem_contribute/operations/fork_spec.rb
+++ b/spec/gem_contribute/operations/fork_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GemContribute::Operations::Fork do
       GemContribute::HostAdapter::ForkResult.new(
         clone_url: "https://github.com/alice/sidekiq.git",
         fork_url: "https://github.com/alice/sidekiq",
-        viewer: "alice", reused: false
+        viewer: "alice", reused: false, owned_upstream: false
       )
     )
 
@@ -35,19 +35,30 @@ RSpec.describe GemContribute::Operations::Fork do
       clone_url: "https://github.com/alice/sidekiq.git",
       fork_url: "https://github.com/alice/sidekiq",
       upstream_url: "https://github.com/sidekiq/sidekiq",
-      viewer: "alice", reused: false
+      viewer: "alice", reused: false, owned_upstream: false
     )
   end
 
   it "preserves the reused flag from the adapter" do
     allow(adapter).to receive(:fork).and_return(
       GemContribute::HostAdapter::ForkResult.new(
-        clone_url: "x", fork_url: "y", viewer: "alice", reused: true
+        clone_url: "x", fork_url: "y", viewer: "alice", reused: true, owned_upstream: false
       )
     )
 
     result = operation.call(adapter: adapter, project: project)
     expect(result.value!.reused).to be(true)
+  end
+
+  it "preserves owned_upstream: true from the adapter" do
+    allow(adapter).to receive(:fork).and_return(
+      GemContribute::HostAdapter::ForkResult.new(
+        clone_url: "x", fork_url: "y", viewer: "sidekiq", reused: true, owned_upstream: true
+      )
+    )
+
+    result = operation.call(adapter: adapter, project: project)
+    expect(result.value!.owned_upstream).to be(true)
   end
 
   it "returns Failure(:unauthenticated) when the adapter raises AuthRequired" do


### PR DESCRIPTION
## Summary

When the authenticated user is the upstream owner (e.g. running `fix` on their own gem), `fork` no longer tries to fork the repo into itself. Instead it clones directly and surfaces a clear "You own … upstream. Cloning directly; no fork needed." message in the CLI output. The `reused` field on `ForkResult` / `Fork::Result` is joined by a new `owned_upstream` boolean to carry this distinction through the pipeline.

## Linked issue / ADR

Closes #10. Touches ADR-0011 (HostAdapter owns all host-API verbs) — `owned_upstream` is determined inside the adapter and propagated up, keeping that boundary intact.

## Working agreement

- [x] Single concern (multi-concern PRs get bounced — see [CLAUDE.md](../CLAUDE.md))
- [x] `bin/rubocop` and `bin/rspec` pass locally
- [x] New behavior has a test; bug fix has a regression test
- [x] Async work goes through Rooibos Commands (no direct threads / `Async` / synchronous shellouts)

## Test plan

- `bundle exec rspec spec/gem_contribute/host_adapters/github_adapter_spec.rb` — new example: `owned_upstream: true` returned when viewer == project.owner, no fork_exists? GET fired
- `bundle exec rspec spec/gem_contribute/operations/fork_spec.rb` — `owned_upstream` passes through
- `bundle exec rspec spec/gem_contribute/cli/fix_spec.rb spec/gem_contribute/cli/fork_spec.rb` — owned-upstream message printed in bootstrap
- `bundle exec rspec` — all passing
- `bin/rubocop` — no offenses

## Notes for reviewer

All existing `ForkResult.new` and `Fork::Result.new` call sites (including specs) are updated to include `owned_upstream: false` explicitly so `Data.define` keyword enforcement doesn't silently drop it.