### PR TITLE
feat: preferred_labels config for non-canonical good-first-issue labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented here. The format is based
 
 ## [Unreleased]
 
+### Added
+
+- `preferred_labels` config key — a list of labels `scan` and `issues` query when ranking contributable projects. Default: `["good first issue", "good-first-issue", "help wanted"]`. Set with `gem-contribute config set preferred_labels "label1,label2"`. Each label triggers a separate API request; results are deduped by issue number so a shared label doesn't inflate counts (closes [#1](https://github.com/cdhagmann/gem-contribute/issues/1)).
+
 ### Fixed
 
 - `gem-contribute fix <gem>/<issue>` is now idempotent: re-running the same command switches to the existing `gem-contribute/issue-<N>` branch instead of failing with "branch already exists". The summary line changes to "Resumed: branch … already exists." to make re-runs visually distinct from fresh runs (closes [#54](https://github.com/cdhagmann/gem-contribute/issues/54)).
+- `gem-contribute fix` no longer prints the misleading "You already have a fork" message when you run it against a repo you own. It now prints "You own <owner>/<repo> upstream. Cloning directly; no fork needed." Cloning and branching behavior are unchanged (closes [#10](https://github.com/cdhagmann/gem-contribute/issues/10)).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ gem-contribute scan
 Scanning Gemfile.lock (44 gems)...
 44 gems · 42 on github.com · 2 unknown source
 
-Top contributable projects (by open `good first issue` count):
+Top contributable projects (by open contributable issue count):
   rubocop          4  github.com/rubocop/rubocop
   rspec            1  github.com/rspec/rspec
   rspec-core       1  github.com/rspec/rspec
@@ -46,7 +46,7 @@ The CLI is a small set of subcommands:
 ```
 gem-contribute init                   One-time interactive setup (sets clone_root, then auth).
 gem-contribute scan [path]            Summarize the contributable surface of a Gemfile.lock.
-gem-contribute issues <gem|all>       List "good first issue" issues for one gem (or all).
+gem-contribute issues <gem|all>       List contributable issues for one gem (or all).
 gem-contribute auth login             Authenticate with GitHub via OAuth device flow.
 gem-contribute fork <gem|owner/repo>  Fork and clone any GitHub repo, land on the default branch.
 gem-contribute fix <gem>/<issue#>     Fork, clone, and branch from main for a specific issue.
@@ -86,9 +86,20 @@ gem-contribute config set clone_root ~/Projects/oss
 gem-contribute config list
 ```
 
-| Key          | Notes                                                                              |
-|--------------|------------------------------------------------------------------------------------|
-| `clone_root` | Where `fix` clones forks (`<root>/<owner>/<repo>`). Set via `init` or `config set`. No default — `fix` errors if unset. |
+| Key                | Default | Notes |
+|--------------------|---------|-------|
+| `clone_root`       | _(none)_ | Where `fix` and `fork` clone repos (`<root>/<owner>/<repo>`). Set via `init` or `config set`. `fix` errors if unset. |
+| `editor`           | `$EDITOR` | Editor launched by `fix -e` / `fork -e`. Falls back to `$EDITOR` if unset. |
+| `ai_tool`          | _(none)_ | AI coding tool launched by `fix -a` / `fork -a` with the clone directory as cwd. |
+| `comment_on_fix`   | `true` | Post a "working on this" comment on the issue when `fix` runs. Set to `false` to opt out globally; use `--no-comment` to opt out per invocation. |
+| `preferred_labels` | `["good first issue", "good-first-issue", "help wanted"]` | Labels `scan` and `issues` query when counting contributable work. Each label is fetched separately (GitHub's API applies AND logic when labels are joined), then deduplicated by issue number. Pass a comma-separated string or set a YAML list directly. |
+
+Per-repo comment overrides (`comment_on_fix_overrides`) are YAML-only — edit `~/.config/gem-contribute/config.yml` directly:
+
+```yaml
+comment_on_fix_overrides:
+  owner/repo: false
+```
 
 ## Design
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -52,7 +52,7 @@ CLI only — no TUI from the plugins. Reasoning: Bundler and RubyGems plugins ar
 
 ## Q3a. ~~Bare-call default for the plugins: `scan` or `list all`?~~ — ANSWERED 2026-05-05
 
-`scan`. Matches `bundle fund` — runs immediately and prints a ranked summary, no subcommand needed. Tracked as [#63](https://github.com/cdhagmann/gem-contribute/issues/63).
+`scan`. Matches `bundle fund` — runs immediately and prints a ranked summary, no subcommand needed. Decision folded into [#38](https://github.com/cdhagmann/gem-contribute/issues/38) and [#39](https://github.com/cdhagmann/gem-contribute/issues/39).
 
 ---
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -50,14 +50,9 @@ CLI only — no TUI from the plugins. Reasoning: Bundler and RubyGems plugins ar
 
 ---
 
-## Q3a. Bare-call default for the plugins: `scan` or `list all`?
+## Q3a. ~~Bare-call default for the plugins: `scan` or `list all`?~~ — ANSWERED 2026-05-05
 
-User flagged as undecided. Both are read-only summary actions; difference is granularity and verbosity.
-
-- **`scan`** — current verb; prints the summary table (`47 gems · 44 on github.com · 2 on gitlab.com · …`) plus top contributable projects by issue count. Hits the network for the issue counts (cached).
-- **`list all`** — would presumably print every gem with its resolved source. Less network, more data, less curated.
-
-No urgency to pick — can be deferred to Phase 4. Worth deciding alongside the verb taxonomy review (does `list` exist as a separate verb? sub-verbs of `list`?).
+`scan`. Matches `bundle fund` — runs immediately and prints a ranked summary, no subcommand needed. Tracked as [#63](https://github.com/cdhagmann/gem-contribute/issues/63).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -162,7 +162,7 @@ A `plugins.rb` entry point at the root of the gem registers a Bundler plugin com
 
 **Constraints:**
 - Plugin entry point MUST NOT require Rooibos or `ratatui_ruby` (per ADR-0014). TUI loading is gated to the standalone binary.
-- Bare `bundle contribute` runs `scan` (resolved per OPEN_QUESTIONS Q3a; tracked as [#63](https://github.com/cdhagmann/gem-contribute/issues/63)).
+- Bare `bundle contribute` runs `scan` (resolved per OPEN_QUESTIONS Q3a).
 - `bundle contribute <verb>` mirrors `gem-contribute <verb>`.
 
 **Acceptance:**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,17 +29,20 @@ This document is the plan. Decisions still in flight live in [`OPEN_QUESTIONS.md
 - **CLI verbs.** `init`, `scan`, `issues`, `config`, `auth`, `fork`, `fix`, `submit`.
 - **HostAdapter cleanup.** ADR-0011 work landed: adapter owns host verbs, Operations layer composes them, CLI verbs compose Operations.
 - **ADR-0012 service layer (Phase 1).** dry-monads `Result`, dry-operation pipelines, dry-initializer initializers, output-free `Operations::*`. Merged via [PR #48](https://github.com/cdhagmann/gem-contribute/pull/48) on 2026-05-04.
-- **Basic CI.** rubocop + rspec on push/PR landed via [PR #21](https://github.com/cdhagmann/gem-contribute/pull/21) (closes [#7](https://github.com/cdhagmann/gem-contribute/issues/7)). Plugin-install smoke and gated integration tests still pending under [#43](https://github.com/cdhagmann/gem-contribute/issues/43).
+- **Basic CI.** rubocop + rspec on push/PR landed via [PR #21](https://github.com/cdhagmann/gem-contribute/pull/21) (closes [#7](https://github.com/cdhagmann/gem-contribute/issues/7)). Plugin-install smoke deferred to v1.x.
 - **PR template + automated check** ([PR #53](https://github.com/cdhagmann/gem-contribute/pull/53)). Tooling, not part of the v1 phases per se.
 - **ADR-0012 Phase 2 (CLI output pipeline).** `Output::Standard`/`Output::Null`, `tty-spinner`-backed `#progress`, `tty-prompt` in Init. Merged via [PR #51](https://github.com/cdhagmann/gem-contribute/pull/51) on 2026-05-04.
+- **Phase 6 polish (all but #9 and the v1.0 tag).** `preferred_labels` config (#1, [PR #60](https://github.com/cdhagmann/gem-contribute/pull/60)), owned-upstream fix message (#10, [PR #59](https://github.com/cdhagmann/gem-contribute/pull/59)), idempotent `fix` re-runs (#54, [PR #61](https://github.com/cdhagmann/gem-contribute/pull/61)), workshop docs archived (#45, [PR #58](https://github.com/cdhagmann/gem-contribute/pull/58)), release infrastructure (#40–#44, [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55)), README rewritten (#46, [PR #56](https://github.com/cdhagmann/gem-contribute/pull/56)).
 
 ## In flight
 
-- **Release infrastructure (Phase 6, partial)** — `release.yml` Trusted Publishing workflow + 0.3.1 cut. Open in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55).
+Nothing — Phase 6 polish is landing. See Phase 6 below.
 
 ## What hasn't started
 
-- Remaining release infrastructure (CONTRIBUTING.md polish, README rewrite, plugin smoke tests, the v1.0 tag itself)
+- [#9](https://github.com/cdhagmann/gem-contribute/issues/9) — `--label LABEL` flag for one-off overrides (deferred past v1.0)
+- Plugin smoke tests (deferred to v1.x with the plugins themselves; tracked under [#43](https://github.com/cdhagmann/gem-contribute/issues/43))
+- The v1.0 tag itself
 - v1.x work (plugins, multi-host adapters)
 - v2.0 work (Rooibos TUI)
 
@@ -123,20 +126,20 @@ Moved CLI verbs to a semantic output abstraction so the look-and-feel can evolve
 Everything required to call it 1.0 and not 0.x. Phase number stays at 6 to preserve the existing `phase:6` issue labels and historical references; in the post-ADR-0015 ordering it's the third remaining v1.0 phase.
 
 **Pre-existing user-facing issues that fold into this phase:**
-- [ ] 🌱 [#1 — Add `preferred_labels` config so non-canonical good-first-issue labels are caught](https://github.com/cdhagmann/gem-contribute/issues/1)
-- [ ] 🌱 [#9 — Add `--label LABEL` flag to scan and issues for one-off overrides](https://github.com/cdhagmann/gem-contribute/issues/9) (related to #1)
-- [ ] 🌱 [#10 — Friendlier message when `fix` runs against a repo you own](https://github.com/cdhagmann/gem-contribute/issues/10)
-- [ ] 🌱 [#54 — Make `fix` re-runs idempotent (don't error when branch already exists)](https://github.com/cdhagmann/gem-contribute/issues/54)
+- [x] 🌱 [#1 — Add `preferred_labels` config so non-canonical good-first-issue labels are caught](https://github.com/cdhagmann/gem-contribute/issues/1) — [PR #60](https://github.com/cdhagmann/gem-contribute/pull/60)
+- [ ] 🌱 [#9 — Add `--label LABEL` flag to scan and issues for one-off overrides](https://github.com/cdhagmann/gem-contribute/issues/9) (related to #1; deferred past v1.0)
+- [x] 🌱 [#10 — Friendlier message when `fix` runs against a repo you own](https://github.com/cdhagmann/gem-contribute/issues/10) — [PR #59](https://github.com/cdhagmann/gem-contribute/pull/59)
+- [x] 🌱 [#54 — Make `fix` re-runs idempotent (don't error when branch already exists)](https://github.com/cdhagmann/gem-contribute/issues/54) — [PR #61](https://github.com/cdhagmann/gem-contribute/pull/61)
 
 **Release infrastructure:**
-- [ ] 🌱 [#40](https://github.com/cdhagmann/gem-contribute/issues/40) — Add CHANGELOG.md *(file exists; close when satisfied)*
-- [ ] 🌱 [#41](https://github.com/cdhagmann/gem-contribute/issues/41) — Add CONTRIBUTING.md *(file exists; close when satisfied)*
-- [ ] [#42](https://github.com/cdhagmann/gem-contribute/issues/42) — MAINTAINER.md (release process, OAuth App, plugin verification) *(release-process and OAuth sections done in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55); plugin verification deferred to v1.x with the plugins themselves)*
-- [ ] OAuth App: stay on personal-account App for v1.0 (per Q13); migrate when rate limits bite
-- [ ] [#43](https://github.com/cdhagmann/gem-contribute/issues/43) — CI workflow: rubocop + rspec done; gated integration tests still pending; plugin install smoke deferred to v1.x with plugins
-- [x] [#44](https://github.com/cdhagmann/gem-contribute/issues/44) — Release workflow with **Trusted Publishing (OIDC)** (in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55), goes live with the 0.3.1 cut)
-- [ ] 🌱 [#45](https://github.com/cdhagmann/gem-contribute/issues/45) — Archive workshop docs to `docs/archive/`
-- [x] [#46](https://github.com/cdhagmann/gem-contribute/issues/46) — README rewrite for v1 audience (CLI-only framing per ADR-0015; "TUI coming in v2.0", "plugins coming in v1.x") — done in [PR #56](https://github.com/cdhagmann/gem-contribute/pull/56)
+- [x] 🌱 [#40](https://github.com/cdhagmann/gem-contribute/issues/40) — Add CHANGELOG.md *(closed — file exists and is maintained)*
+- [x] 🌱 [#41](https://github.com/cdhagmann/gem-contribute/issues/41) — Add CONTRIBUTING.md *(closed — file exists)*
+- [x] [#42](https://github.com/cdhagmann/gem-contribute/issues/42) — MAINTAINER.md *(closed — release-process and OAuth sections done in [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55); plugin verification deferred to v1.x with the plugins themselves)*
+- [x] OAuth App: stay on personal-account App for v1.0 (per Q13); migrate when rate limits bite
+- [x] [#43](https://github.com/cdhagmann/gem-contribute/issues/43) — CI workflow: rubocop + rspec on push/PR done *(closed — plugin install smoke deferred to v1.x with plugins)*
+- [x] [#44](https://github.com/cdhagmann/gem-contribute/issues/44) — Release workflow with **Trusted Publishing (OIDC)** — [PR #55](https://github.com/cdhagmann/gem-contribute/pull/55)
+- [x] 🌱 [#45](https://github.com/cdhagmann/gem-contribute/issues/45) — Archive workshop docs to `docs/archive/` — [PR #58](https://github.com/cdhagmann/gem-contribute/pull/58)
+- [x] [#46](https://github.com/cdhagmann/gem-contribute/issues/46) — README rewrite for v1 audience — [PR #56](https://github.com/cdhagmann/gem-contribute/pull/56)
 - [ ] Tag `v1.0.0`, push to rubygems
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -162,7 +162,7 @@ A `plugins.rb` entry point at the root of the gem registers a Bundler plugin com
 
 **Constraints:**
 - Plugin entry point MUST NOT require Rooibos or `ratatui_ruby` (per ADR-0014). TUI loading is gated to the standalone binary.
-- Bare `bundle contribute` runs the default verb (TBD per OPEN_QUESTIONS Q3a: `scan` or `list all`).
+- Bare `bundle contribute` runs `scan` (resolved per OPEN_QUESTIONS Q3a; tracked as [#63](https://github.com/cdhagmann/gem-contribute/issues/63)).
 - `bundle contribute <verb>` mirrors `gem-contribute <verb>`.
 
 **Acceptance:**
@@ -179,7 +179,7 @@ A `rubygems_plugin.rb` entry point registers a `Gem::Command` subclass per RubyG
 
 **Constraints:**
 - Same TUI-load gating as the Bundler plugin.
-- Same default-verb behavior as the Bundler plugin.
+- Bare `gem contribute` runs `scan` (same decision as Q3a above).
 
 **Acceptance:**
 - [ ] `gem install gem-contribute` registers the `Gem::Command`

--- a/lib/gem_contribute/cli/issues.rb
+++ b/lib/gem_contribute/cli/issues.rb
@@ -12,16 +12,16 @@ module GemContribute
     class Issues
       include Workflow
 
-      DEFAULT_LABEL = "good first issue"
-
       def initialize(stdout: $stdout, stderr: $stderr, output: nil,
                      resolver: Resolver.new,
                      adapter: HostAdapters::GitHubAdapter.new,
-                     lockfile_path: "Gemfile.lock")
+                     lockfile_path: "Gemfile.lock",
+                     config: GemContribute::Config.new)
         @output = output || Output::Standard.new(out: stdout, err: stderr)
         @resolver = resolver
         @adapter = adapter
         @lockfile_path = lockfile_path
+        @config = config
       end
 
       def run(argv)
@@ -69,22 +69,35 @@ module GemContribute
           print_project_issues(project, issues)
         end
 
-        @output.info("(no good first issues found across #{projects.size} gems)") unless any
+        @output.info("(no contributable issues found across #{projects.size} gems)") unless any
         0
       rescue LockfileNotFound => e
         @output.error("gem-contribute: #{e.message}")
         1
       end
 
+      def issues_for_project(project)
+        errors = []
+        issues = @config.preferred_labels.flat_map do |label|
+          @adapter.issues(project, labels: [label])
+        rescue AdapterError => e
+          errors << e
+          []
+        end
+        raise errors.first if issues.empty? && errors.any?
+
+        issues.uniq { |i| i["number"] }
+      end
+
       def fetch_issues(project)
-        @adapter.issues(project, labels: [DEFAULT_LABEL])
+        issues_for_project(project)
       rescue AdapterError => e
         @output.warn("  warning: #{project.gem_name}: #{e.message}")
         []
       end
 
       def list_issues(project)
-        issues = @adapter.issues(project, labels: [DEFAULT_LABEL])
+        issues = issues_for_project(project)
         print_project_issues(project, issues)
         @output.info("To contribute: gem-contribute fix #{project.gem_name}/<issue#>")
         0
@@ -92,7 +105,7 @@ module GemContribute
 
       def print_project_issues(project, issues)
         repo_url = "https://github.com/#{project.owner}/#{project.repo}"
-        @output.info("#{project.gem_name} — #{issues.size} open \"#{DEFAULT_LABEL}\" issues (#{repo_url})")
+        @output.info("#{project.gem_name} — #{issues.size} open contributable issues (#{repo_url})")
 
         if issues.empty?
           @output.info("  (none — browse #{repo_url}/issues directly)")

--- a/lib/gem_contribute/cli/scan.rb
+++ b/lib/gem_contribute/cli/scan.rb
@@ -14,19 +14,14 @@ module GemContribute
     #     <gem-name>  <count>  <github.com/owner/repo>
     #     ...
     class Scan
-      # GitHub's `labels=foo,bar` query is an AND, not an OR, so passing the
-      # full set of beginner-friendly variants returns almost nothing. Stage 1
-      # uses the canonical `good first issue` label only — the "render labels
-      # verbatim" promise in ADR-0005 belongs to display, not to server-side
-      # filtering. Future stages can call once per label and dedupe.
-      DEFAULT_LABEL = "good first issue"
-
       def initialize(stdout: $stdout, stderr: $stderr, output: nil,
                      resolver: Resolver.new,
-                     adapter: HostAdapters::GitHubAdapter.new)
+                     adapter: HostAdapters::GitHubAdapter.new,
+                     config: GemContribute::Config.new)
         @output = output || Output::Standard.new(out: stdout, err: stderr)
         @resolver = resolver
         @adapter = adapter
+        @config = config
       end
 
       # @param argv [Array<String>] passed-in args (no leading "scan")
@@ -99,11 +94,18 @@ module GemContribute
       end
 
       def issue_count(project)
-        issues = @adapter.issues(project, labels: [DEFAULT_LABEL])
-        issues.size
-      rescue AdapterError, AuthRequired => e
-        @output.warn("  warning: #{project.gem_name} (#{project.host}/#{project.owner}/#{project.repo}): #{e.message}")
-        0
+        warned = false
+        issues = @config.preferred_labels.flat_map do |label|
+          @adapter.issues(project, labels: [label])
+        rescue AdapterError, AuthRequired => e
+          unless warned
+            location = "#{project.host}/#{project.owner}/#{project.repo}"
+            @output.warn("  warning: #{project.gem_name} (#{location}): #{e.message}")
+            warned = true
+          end
+          []
+        end
+        issues.uniq { |i| i["number"] }.size
       end
 
       def print_ranked(ranked, claim_index)

--- a/lib/gem_contribute/config.rb
+++ b/lib/gem_contribute/config.rb
@@ -8,7 +8,8 @@ module GemContribute
   # Honors XDG_CONFIG_HOME so tests stay hermetic and unusual layouts work.
   # Missing or corrupt files are treated as an empty config (no crash).
   class Config
-    KNOWN_KEYS = %w[clone_root editor ai_tool comment_on_fix].freeze
+    KNOWN_KEYS = %w[clone_root editor ai_tool comment_on_fix preferred_labels].freeze
+    DEFAULT_PREFERRED_LABELS = ["good first issue", "good-first-issue", "help wanted"].freeze
 
     def initialize(path: self.class.default_path)
       @path = path
@@ -31,6 +32,11 @@ module GemContribute
     # Returns whether `fix` should post a "working on this" comment.
     # Pass a repo (`"owner/repo"`) to check the per-repo override; without
     # a repo, returns the global default. Default is true when unset.
+    def preferred_labels
+      raw = @data["preferred_labels"]
+      raw.nil? ? DEFAULT_PREFERRED_LABELS : Array(raw)
+    end
+
     def comment_on_fix?(repo = nil)
       overrides = @data["comment_on_fix_overrides"]
       return truthy?(overrides[repo]) if repo && overrides.is_a?(Hash) && overrides.key?(repo)
@@ -43,7 +49,7 @@ module GemContribute
       raise ArgumentError, "unknown config key #{key.inspect}. Known keys: #{KNOWN_KEYS.join(", ")}" \
         unless KNOWN_KEYS.include?(key)
 
-      @data[key] = value
+      @data[key] = key == "preferred_labels" ? coerce_label_list(value) : value
       write_file
     end
 
@@ -57,6 +63,12 @@ module GemContribute
     end
 
     private
+
+    def coerce_label_list(value)
+      return value if value.is_a?(Array)
+
+      value.to_s.split(",").map(&:strip).reject(&:empty?)
+    end
 
     def truthy?(value)
       case value

--- a/spec/gem_contribute/cli/issues_spec.rb
+++ b/spec/gem_contribute/cli/issues_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe GemContribute::CLI::Issues do
       allow(adapter).to receive(:issues).and_return([])
 
       expect(cli.run(["all"])).to eq(0)
-      expect(stdout.string).to include("no good first issues found")
+      expect(stdout.string).to include("no contributable issues found")
     end
 
     it "skips gems whose adapter call fails and continues" do
@@ -153,6 +153,45 @@ RSpec.describe GemContribute::CLI::Issues do
       expect(stdout.string).to include("#42")
     end
   end
+
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
+  describe "preferred_labels" do
+    let(:tmpdir) { Dir.mktmpdir("gem-contribute-issues-config-") }
+    let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
+    let(:cli_with_config) do
+      described_class.new(stdout: stdout, stderr: stderr,
+                          resolver: resolver, adapter: adapter,
+                          lockfile_path: lockfile, config: config)
+    end
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    it "dedupes issues returned for multiple labels by issue number" do
+      shared_issue = issue(1234, "Shared issue")
+      allow(adapter).to receive(:issues).with(project, labels: ["good first issue"])
+                                        .and_return([shared_issue])
+      allow(adapter).to receive(:issues).with(project, labels: ["good-first-issue"])
+                                        .and_return([shared_issue, issue(5678, "Other issue")])
+      allow(adapter).to receive(:issues).with(project, labels: ["help wanted"])
+                                        .and_return([])
+
+      expect(cli_with_config.run(["rubocop"])).to eq(0)
+      expect(stdout.string).to include("#1234")
+      expect(stdout.string).to include("#5678")
+      expect(stdout.string).to match(/2 open/)
+    end
+
+    it "uses custom preferred_labels from config instead of defaults" do
+      config.set("preferred_labels", "help wanted")
+      allow(adapter).to receive(:issues).with(project, labels: ["help wanted"])
+                                        .and_return([issue(99, "Help wanted issue")])
+
+      expect(cli_with_config.run(["rubocop"])).to eq(0)
+      expect(stdout.string).to include("#99")
+      expect(adapter).not_to have_received(:issues).with(project, labels: ["good first issue"])
+    end
+  end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
   describe "rate-limit footer" do
     it "appends the footer after `issues <gem>` when adapter recorded one" do

--- a/spec/gem_contribute/cli/scan_spec.rb
+++ b/spec/gem_contribute/cli/scan_spec.rb
@@ -147,4 +147,37 @@ RSpec.describe GemContribute::CLI::Scan do
     expect(scan.run([lockfile])).to eq(0)
     expect(stdout.string).not_to include("GitHub rate limit")
   end
+
+  describe "preferred_labels" do
+    let(:tmpdir) { Dir.mktmpdir("gem-contribute-scan-config-") }
+    let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
+    let(:scan_with_config) do
+      described_class.new(stdout: stdout, stderr: stderr,
+                          resolver: resolver, adapter: adapter, config: config)
+    end
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    it "dedupes issues by number across preferred labels so a shared issue is counted once" do
+      allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
+      shared = { "number" => 1 }
+      allow(adapter).to receive(:issues).with(anything, labels: ["good first issue"]).and_return([shared])
+      allow(adapter).to receive(:issues).with(anything, labels: ["good-first-issue"]).and_return([shared])
+      allow(adapter).to receive(:issues).with(anything, labels: ["help wanted"]).and_return([])
+
+      expect(scan_with_config.run([lockfile])).to eq(0)
+      expect(stdout.string).to match(/rake\s+1\s+/)
+    end
+
+    it "uses custom preferred_labels from config" do
+      config.set("preferred_labels", "help wanted")
+      allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
+      allow(adapter).to receive(:issues).with(anything, labels: ["help wanted"])
+                                        .and_return([{ "number" => 42 }])
+
+      expect(scan_with_config.run([lockfile])).to eq(0)
+      expect(stdout.string).to match(/rake\s+1\s+/)
+      expect(adapter).not_to have_received(:issues).with(anything, labels: ["good first issue"])
+    end
+  end
 end

--- a/spec/gem_contribute/config_spec.rb
+++ b/spec/gem_contribute/config_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe GemContribute::Config do
     end
   end
 
+  describe "#preferred_labels" do
+    it "returns the defaults when not configured" do
+      expect(config.preferred_labels).to eq(GemContribute::Config::DEFAULT_PREFERRED_LABELS)
+    end
+
+    it "returns the configured list when set as a YAML array" do
+      File.write(path, YAML.dump("preferred_labels" => ["help wanted", "beginner"]))
+      expect(config.preferred_labels).to eq(["help wanted", "beginner"])
+    end
+  end
+
   describe "#set" do
     it "writes the value and makes it readable" do
       config.set("clone_root", "~/code/gems")
@@ -90,6 +101,18 @@ RSpec.describe GemContribute::Config do
 
     it "raises ArgumentError for unknown keys" do
       expect { config.set("unknown_key", "value") }.to raise_error(ArgumentError, /unknown config key/)
+    end
+
+    it "parses preferred_labels from a comma-separated string" do
+      config.set("preferred_labels", "good first issue, help wanted")
+      reloaded = described_class.new(path: path)
+      expect(reloaded.preferred_labels).to eq(["good first issue", "help wanted"])
+    end
+
+    it "stores preferred_labels as an array when given one" do
+      config.set("preferred_labels", ["good first issue", "beginner"])
+      reloaded = described_class.new(path: path)
+      expect(reloaded.preferred_labels).to eq(["good first issue", "beginner"])
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a `preferred_labels` config key so users can customise which issue labels `scan` and `issues` treat as "contributable". Defaults to `["good first issue", "good-first-issue", "help wanted"]`. Because GitHub's label API applies AND semantics when multiple labels are joined in one request, each label is fetched separately and results are deduped client-side by issue number.

## Linked issue / ADR

Closes #1. Touches ADR-0005 (label normalisation is still out of scope — this is label *selection*, not normalisation).

## Working agreement

- [x] Single concern (multi-concern PRs get bounced — see [CLAUDE.md](../CLAUDE.md))
- [x] `bin/rubocop` and `bin/rspec` pass locally
- [x] New behavior has a test; bug fix has a regression test
- [x] Async work goes through Rooibos Commands (no direct threads / `Async` / synchronous shellouts)

## Test plan

- `bundle exec rspec spec/gem_contribute/config_spec.rb` — preferred_labels default, array override, comma-string coercion
- `bundle exec rspec spec/gem_contribute/cli/scan_spec.rb spec/gem_contribute/cli/issues_spec.rb` — per-label fetch, dedup
- `bundle exec rspec` — all passing
- `bin/rubocop` — no offenses

## Notes for reviewer

`gem-contribute config set preferred_labels "bug,help wanted"` coerces the comma-separated string to an array at write time, so the YAML is always an array. Reading always returns an Array regardless.