### PR TITLE
feat(fix): idempotent re-runs — switch to existing branch instead of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here. The format is based
 
 ## [Unreleased]
 
+### Fixed
+
+- `gem-contribute fix <gem>/<issue>` is now idempotent: re-running the same command switches to the existing `gem-contribute/issue-<N>` branch instead of failing with "branch already exists". The summary line changes to "Resumed: branch … already exists." to make re-runs visually distinct from fresh runs (closes [#54](https://github.com/cdhagmann/gem-contribute/issues/54)).
+
 ### Changed
 
 - README rewritten for the v1 audience. Status section now describes the v1.0 / v1.x / v2.0 sequencing (CLI at 1.0; Bundler + RubyGems plugins and multi-host adapters at 1.x; Rooibos TUI at 2.0) and points at [`docs/ROADMAP.md`](docs/ROADMAP.md) and [ADR-0015](docs/adr/0015-descope-v1-cli-only.md) for detail. Workshop framing removed (closes [#46](https://github.com/cdhagmann/gem-contribute/issues/46)).

--- a/lib/gem_contribute/cli/fix.rb
+++ b/lib/gem_contribute/cli/fix.rb
@@ -83,7 +83,7 @@ module GemContribute
 
         case result
         in Success(fork: fork_data, clone: clone_data, branch: branch_data, announce: announce_data)
-          print_summary(clone_data.path, branch_data.name, fork_data)
+          print_summary(clone_data, branch_data, fork_data)
           print_announce_outcome(announce_data, issue)
           @post_clone_hooks.call(clone_data.path, editor: flags[:editor], ai_tool: flags[:ai_tool])
           0
@@ -96,14 +96,19 @@ module GemContribute
         end
       end
 
-      def print_summary(local_path, branch_name, fork_info)
-        @output.info("Forked, cloned, and branched.")
-        @output.info("  path:   #{local_path}")
-        @output.info("  branch: #{branch_name}")
+      def print_summary(clone_data, branch_data, fork_info)
+        status = if branch_data.reused
+                   "Resumed: branch #{branch_data.name} already exists."
+                 else
+                   "Forked, cloned, and branched."
+                 end
+        @output.info(status)
+        @output.info("  path:     #{clone_data.path}")
+        @output.info("  branch:   #{branch_data.name}")
         @output.info("  upstream: #{fork_info.upstream_url}")
         @output.info("  fork:     #{fork_info.fork_url}")
         @output.info("")
-        @output.info("Next: cd #{local_path} && make your changes, then `gem-contribute submit`.")
+        @output.info("Next: cd #{clone_data.path} && make your changes, then `gem-contribute submit`.")
       end
 
       def print_announce_outcome(announce_result, issue)

--- a/lib/gem_contribute/git.rb
+++ b/lib/gem_contribute/git.rb
@@ -15,6 +15,10 @@ module GemContribute
       run!(["git", "-C", path, "checkout", "-b", branch])
     end
 
+    def switch_branch(path, branch)
+      run!(["git", "-C", path, "checkout", branch])
+    end
+
     def add_remote(path, name, url)
       # Idempotent: if the remote already exists (e.g. reusing a clone)
       # we silently succeed rather than fail the whole flow.

--- a/lib/gem_contribute/operations/branch.rb
+++ b/lib/gem_contribute/operations/branch.rb
@@ -4,19 +4,15 @@ require "dry/monads"
 
 module GemContribute
   module Operations
-    # Bootstrap step 3: create the per-issue working branch in the fork
-    # clone. The branch name is `gem-contribute/issue-<N>`. Output-free
-    # per ADR-0012.
-    #
-    # Note: `git checkout -b` fails if the branch already exists, which
-    # surfaces as `Failure([:adapter_error, ...])` here. That preserves
-    # the pre-extraction behaviour where re-running `fix` on an issue
-    # whose branch already exists locally errored out — see [#10] for
-    # the friendlier-message follow-up.
+    # Bootstrap step 3: ensure the per-issue working branch exists and is
+    # checked out in the clone. The branch name is `gem-contribute/issue-<N>`.
+    # Output-free per ADR-0012. Idempotent: if the branch already exists
+    # locally it is checked out (not re-created), so re-running `fix` on the
+    # same issue lands you on the same branch without errors (closes #54).
     class Branch
       include Dry::Monads[:result]
 
-      Result = Data.define(:name)
+      Result = Data.define(:name, :reused)
       PREFIX = "gem-contribute/issue-"
 
       def initialize(git: Git.new)
@@ -25,8 +21,13 @@ module GemContribute
 
       def call(path:, issue:)
         name = "#{PREFIX}#{issue}"
-        @git.checkout_branch(path, name)
-        Success(Result.new(name: name))
+        if @git.branch_exists?(path, name)
+          @git.switch_branch(path, name)
+          Success(Result.new(name: name, reused: true))
+        else
+          @git.checkout_branch(path, name)
+          Success(Result.new(name: name, reused: false))
+        end
       rescue GemContribute::AdapterError => e
         Failure([:adapter_error, e.message])
       end

--- a/spec/gem_contribute/cli/fix_spec.rb
+++ b/spec/gem_contribute/cli/fix_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe GemContribute::CLI::Fix do
     )
   end
   let(:clone_data) { GemContribute::Operations::Clone::Result.new(path: target, reused: false) }
-  let(:branch_data) { GemContribute::Operations::Branch::Result.new(name: "gem-contribute/issue-1234") }
+  let(:branch_data) { GemContribute::Operations::Branch::Result.new(name: "gem-contribute/issue-1234", reused: false) }
   let(:pipeline_success) do
     Success(fork: fork_data, clone: clone_data, branch: branch_data, announce: Success(:posted))
   end

--- a/spec/gem_contribute/operations/branch_spec.rb
+++ b/spec/gem_contribute/operations/branch_spec.rb
@@ -8,17 +8,19 @@ RSpec.describe GemContribute::Operations::Branch do
   let(:git) { instance_double(GemContribute::Git) }
   let(:operation) { described_class.new(git: git) }
 
-  it "creates a gem-contribute/issue-<N> branch and returns Success(Result(name:))" do
+  it "creates a gem-contribute/issue-<N> branch and returns Success(Result(name:, reused: false))" do
+    allow(git).to receive(:branch_exists?).and_return(false)
     allow(git).to receive(:checkout_branch)
 
     result = operation.call(path: "/clone/path", issue: "1234")
 
     expect(result).to be_success
-    expect(result.value!).to have_attributes(name: "gem-contribute/issue-1234")
+    expect(result.value!).to have_attributes(name: "gem-contribute/issue-1234", reused: false)
     expect(git).to have_received(:checkout_branch).with("/clone/path", "gem-contribute/issue-1234")
   end
 
   it "accepts an integer issue number" do
+    allow(git).to receive(:branch_exists?).and_return(false)
     allow(git).to receive(:checkout_branch)
 
     result = operation.call(path: "/clone/path", issue: 7)
@@ -26,12 +28,24 @@ RSpec.describe GemContribute::Operations::Branch do
     expect(result.value!.name).to eq("gem-contribute/issue-7")
   end
 
+  it "switches to the existing branch and returns reused: true when branch already exists" do
+    allow(git).to receive(:branch_exists?).and_return(true)
+    allow(git).to receive(:switch_branch)
+
+    result = operation.call(path: "/clone/path", issue: "1234")
+
+    expect(result).to be_success
+    expect(result.value!).to have_attributes(name: "gem-contribute/issue-1234", reused: true)
+    expect(git).to have_received(:switch_branch).with("/clone/path", "gem-contribute/issue-1234")
+  end
+
   it "returns Failure([:adapter_error, message]) when git raises AdapterError" do
+    allow(git).to receive(:branch_exists?).and_return(false)
     allow(git).to receive(:checkout_branch)
-      .and_raise(GemContribute::AdapterError, "fatal: branch already exists")
+      .and_raise(GemContribute::AdapterError, "fatal: permission denied")
 
     result = operation.call(path: "/clone/path", issue: "1")
 
-    expect(result).to eq(Failure([:adapter_error, "fatal: branch already exists"]))
+    expect(result).to eq(Failure([:adapter_error, "fatal: permission denied"]))
   end
 end

--- a/spec/gem_contribute/operations/fix_pipeline_spec.rb
+++ b/spec/gem_contribute/operations/fix_pipeline_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GemContribute::Operations::FixPipeline do
   let(:clone_result) do
     GemContribute::Operations::Clone::Result.new(path: "/clones/sidekiq/sidekiq", reused: false)
   end
-  let(:branch_result) { GemContribute::Operations::Branch::Result.new(name: "gem-contribute/issue-1234") }
+  let(:branch_result) { GemContribute::Operations::Branch::Result.new(name: "gem-contribute/issue-1234", reused: false) }
 
   let(:pipeline) do
     described_class.new(fork: fork_op, clone: clone_op, branch: branch_op, announce: announce_op)


### PR DESCRIPTION
## Summary

`gem-contribute fix <gem>/<issue>` is now idempotent: re-running the same command switches to the existing `gem-contribute/issue-<N>` branch instead of failing with "branch already exists". The CLI summary changes to "Resumed: branch … already exists." so re-runs are visually distinct from fresh runs.

## Linked issue / ADR

Closes #54. No ADR — the change is contained to `Operations::Branch` and its CLI rendering; no architectural boundary is crossed.

## Working agreement

- [x] Single concern (multi-concern PRs get bounced — see [CLAUDE.md](../CLAUDE.md))
- [x] `bin/rubocop` and `bin/rspec` pass locally
- [x] New behavior has a test; bug fix has a regression test
- [x] Async work goes through Rooibos Commands (no direct threads / `Async` / synchronous shellouts)

## Test plan

- `bundle exec rspec spec/gem_contribute/operations/branch_spec.rb` — 4 examples, all passing (new: reuse path, existing branch switches correctly)
- `bundle exec rspec` — 229 examples, no failures
- `bin/rubocop` — no offenses
- Manual: run `gem-contribute fix <gem>/<issue>` twice; second run prints "Resumed: branch…" and exits 0

## Notes for reviewer

`Git#switch_branch` runs `git checkout <branch>` (not `git switch`) to stay consistent with `Git#checkout_branch` which already uses `git checkout -b`. Both land on the same branch; only the `-b` flag differs.