### PR TITLE
feat: batch GitHub Search API with OR semantics for labels and repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented here. The format is based
 ### Added
 
 - `preferred_labels` config key — a list of labels `scan` and `issues` query when ranking contributable projects. Default: `["good first issue", "good-first-issue", "help wanted"]`. Set with `gem-contribute config set preferred_labels "label1,label2"`. Each label triggers a separate API request; results are deduped by issue number so a shared label doesn't inflate counts (closes [#1](https://github.com/cdhagmann/gem-contribute/issues/1)).
+- `scan` and `issues all` now batch all GitHub-hosted repos into a single GitHub Search API call per 10 repos using OR semantics (`(label:"A" OR label:"B") repo:o/r1 repo:o/r2 …`). Replaces N×labels per-project Issues API calls, dramatically reducing network round trips for typical lockfiles.
 
 ### Fixed
 

--- a/lib/gem_contribute/cli/issues.rb
+++ b/lib/gem_contribute/cli/issues.rb
@@ -60,40 +60,36 @@ module GemContribute
 
         @output.info("Scanning #{projects.size} github.com gems from #{@lockfile_path}...\n")
 
-        any = false
-        projects.each do |project|
-          issues = fetch_issues(project)
-          next if issues.empty?
-
-          any = true
-          print_project_issues(project, issues)
-        end
-
-        @output.info("(no contributable issues found across #{projects.size} gems)") unless any
+        issues_by_repo = batch_fetch_issues(projects)
+        print_all_project_issues(projects, issues_by_repo)
         0
       rescue LockfileNotFound => e
         @output.error("gem-contribute: #{e.message}")
         1
       end
 
-      def issues_for_project(project)
-        errors = []
-        issues = @config.preferred_labels.flat_map do |label|
-          @adapter.issues(project, labels: [label])
-        rescue AdapterError => e
-          errors << e
-          []
-        end
-        raise errors.first if issues.empty? && errors.any?
+      def print_all_project_issues(projects, issues_by_repo)
+        any = false
+        projects.each do |project|
+          issues = issues_by_repo["#{project.owner}/#{project.repo}"] || []
+          next if issues.empty?
 
-        issues.uniq { |i| i["number"] }
+          any = true
+          print_project_issues(project, issues)
+        end
+        @output.info("(no contributable issues found across #{projects.size} gems)") unless any
       end
 
-      def fetch_issues(project)
-        issues_for_project(project)
+      def batch_fetch_issues(projects)
+        @adapter.issues_matching_labels(projects, labels: @config.preferred_labels)
       rescue AdapterError => e
-        @output.warn("  warning: #{project.gem_name}: #{e.message}")
-        []
+        @output.warn("  warning: issue search failed: #{e.message}")
+        {}
+      end
+
+      def issues_for_project(project)
+        by_repo = @adapter.issues_matching_labels([project], labels: @config.preferred_labels)
+        by_repo["#{project.owner}/#{project.repo}"] || []
       end
 
       def list_issues(project)

--- a/lib/gem_contribute/cli/scan.rb
+++ b/lib/gem_contribute/cli/scan.rb
@@ -82,30 +82,19 @@ module GemContribute
       end
 
       def rank_by_issue_count(projects)
-        # We hit the API anonymously here. With a 60/hr unauthenticated rate
-        # limit, scanning a 50-gem lockfile is the dominant pressure on this
-        # CLI. The 7-day RubyGems and 5-min issues caches absorb most repeats.
+        issues_by_repo = fetch_issues_for_projects(projects)
         results = projects.map do |project|
-          count = issue_count(project)
+          count = (issues_by_repo["#{project.owner}/#{project.repo}"] || []).size
           [project, count]
-        end.compact
-
+        end
         results.reject { |_, count| count.zero? }.sort_by { |_, count| -count }
       end
 
-      def issue_count(project)
-        warned = false
-        issues = @config.preferred_labels.flat_map do |label|
-          @adapter.issues(project, labels: [label])
-        rescue AdapterError, AuthRequired => e
-          unless warned
-            location = "#{project.host}/#{project.owner}/#{project.repo}"
-            @output.warn("  warning: #{project.gem_name} (#{location}): #{e.message}")
-            warned = true
-          end
-          []
-        end
-        issues.uniq { |i| i["number"] }.size
+      def fetch_issues_for_projects(projects)
+        @adapter.issues_matching_labels(projects, labels: @config.preferred_labels)
+      rescue AdapterError, AuthRequired => e
+        @output.warn("  warning: issue search failed: #{e.message}")
+        {}
       end
 
       def print_ranked(ranked, claim_index)

--- a/lib/gem_contribute/host_adapters/github_adapter.rb
+++ b/lib/gem_contribute/host_adapters/github_adapter.rb
@@ -135,6 +135,30 @@ module GemContribute
         get_json("/repos/#{project.owner}/#{project.repo}/issues/#{number}/comments")
       end
 
+      SEARCH_BATCH_SIZE = 10
+
+      # Fetches open issues matching ANY of the given labels across all
+      # projects, batching repos 10 at a time to stay within URL length
+      # limits. Returns a Hash keyed by "owner/repo" => [issue, ...].
+      #
+      # Uses GitHub's Search API with OR semantics for both labels and repos:
+      #   is:issue state:open (label:"A" OR label:"B") repo:o/r1 repo:o/r2 …
+      #
+      # The Search API caps at 1 000 total results and 30 req/min; for typical
+      # Gemfile.lock sizes this is not a concern.
+      def issues_matching_labels(projects, labels:)
+        return {} if projects.empty? || labels.empty?
+
+        result = Hash.new { |h, k| h[k] = [] }
+        projects.each_slice(SEARCH_BATCH_SIZE) do |batch|
+          fetch_label_batch(batch, labels: labels).each do |issue|
+            key = repo_key_from_search_result(issue)
+            result[key] << issue
+          end
+        end
+        result
+      end
+
       # GET /search/issues. Wraps GitHub's issue search; works without auth
       # (subject to the 60/hr anonymous rate limit). Returns an array of
       # issue payloads (the search response's `items` key). Cached under the
@@ -217,6 +241,26 @@ module GemContribute
 
         raise AdapterError,
               "fork not reachable after #{FORK_READINESS_RETRIES * FORK_READINESS_INTERVAL}s"
+      end
+
+      def fetch_label_batch(projects, labels:)
+        label_q = labels.map { |l| "label:\"#{l}\"" }.join(" OR ")
+        repo_q  = projects.map { |p| "repo:#{p.owner}/#{p.repo}" }.join(" ")
+        query   = "is:issue state:open (#{label_q}) #{repo_q}"
+
+        cache_key = "label_batch:#{query}"
+        cached = @cache.fetch("issues", cache_key)
+        return cached if cached
+
+        raw   = get_json("/search/issues", q: query, per_page: 100)
+        items = raw.fetch("items", [])
+        @cache.write("issues", cache_key, items)
+        items
+      end
+
+      def repo_key_from_search_result(issue)
+        issue.fetch("repository_url", "")
+             .delete_prefix("#{API_BASE}/repos/")
       end
 
       def issue_cache_key(project, labels)

--- a/spec/gem_contribute/cli/issues_spec.rb
+++ b/spec/gem_contribute/cli/issues_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe GemContribute::CLI::Issues do
 
   before do
     allow(resolver).to receive(:resolve).and_return(project)
-    # Default: footer is a no-op unless a test explicitly returns a RateLimit.
     allow(adapter).to receive(:rate_limit).and_return(nil)
-    # Default: no claimed issues. Tests that exercise the prefix override.
     allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index).and_return({})
   end
 
@@ -54,8 +52,8 @@ RSpec.describe GemContribute::CLI::Issues do
   end
 
   it "prefixes claimed issues with a [claimed] label" do
-    allow(adapter).to receive(:issues).and_return(
-      [issue(1234, "Fresh title"), issue(5678, "Already-being-worked-on")]
+    allow(adapter).to receive(:issues_matching_labels).and_return(
+      "rubocop/rubocop" => [issue(1234, "Fresh title"), issue(5678, "Already-being-worked-on")]
     )
     allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index)
       .and_return("rubocop/rubocop" => [5678])
@@ -67,9 +65,9 @@ RSpec.describe GemContribute::CLI::Issues do
   end
 
   it "lists issues with number, title, and URL" do
-    allow(adapter).to receive(:issues).and_return(
-      [issue(1234, "Fix trailing whitespace cop"),
-       issue(5678, "Add config option for XYZ")]
+    allow(adapter).to receive(:issues_matching_labels).and_return(
+      "rubocop/rubocop" => [issue(1234, "Fix trailing whitespace cop"),
+                            issue(5678, "Add config option for XYZ")]
     )
 
     expect(cli.run(["rubocop"])).to eq(0)
@@ -82,7 +80,7 @@ RSpec.describe GemContribute::CLI::Issues do
   end
 
   it "prints a friendly message when no issues are found" do
-    allow(adapter).to receive(:issues).and_return([])
+    allow(adapter).to receive(:issues_matching_labels).and_return({})
 
     expect(cli.run(["rubocop"])).to eq(0)
     expect(stdout.string).to include("0 open")
@@ -90,7 +88,7 @@ RSpec.describe GemContribute::CLI::Issues do
   end
 
   it "exits 1 and prints an error when the adapter raises" do
-    allow(adapter).to receive(:issues).and_raise(GemContribute::AdapterError, "rate limited")
+    allow(adapter).to receive(:issues_matching_labels).and_raise(GemContribute::AdapterError, "rate limited")
 
     expect(cli.run(["rubocop"])).to eq(1)
     expect(stderr.string).to include("rate limited")
@@ -122,10 +120,9 @@ RSpec.describe GemContribute::CLI::Issues do
     end
 
     it "iterates all github.com gems and prints only those with issues" do
-      allow(adapter).to receive(:issues).with(rake_project, anything).and_return(
-        [issue(99, "Fix task", owner: "ruby", repo: "rake")]
+      allow(adapter).to receive(:issues_matching_labels).and_return(
+        "ruby/rake" => [issue(99, "Fix task", owner: "ruby", repo: "rake")]
       )
-      allow(adapter).to receive(:issues).with(sidekiq_project, anything).and_return([])
 
       expect(cli.run(["all"])).to eq(0)
       out = stdout.string
@@ -134,23 +131,20 @@ RSpec.describe GemContribute::CLI::Issues do
     end
 
     it "prints a summary message when no gems have issues" do
-      allow(adapter).to receive(:issues).and_return([])
+      allow(adapter).to receive(:issues_matching_labels).and_return({})
 
       expect(cli.run(["all"])).to eq(0)
       expect(stdout.string).to include("no contributable issues found")
     end
 
-    it "skips gems whose adapter call fails and continues" do
-      allow(adapter).to receive(:issues).with(rake_project, anything).and_raise(
+    it "warns and exits 0 when the batch search fails" do
+      allow(adapter).to receive(:issues_matching_labels).and_raise(
         GemContribute::AdapterError, "rate limited"
-      )
-      allow(adapter).to receive(:issues).with(sidekiq_project, anything).and_return(
-        [issue(42, "Improve batching", owner: "sidekiq", repo: "sidekiq")]
       )
 
       expect(cli.run(["all"])).to eq(0)
       expect(stderr.string).to include("warning")
-      expect(stdout.string).to include("#42")
+      expect(stderr.string).to include("rate limited")
     end
   end
 
@@ -166,57 +160,58 @@ RSpec.describe GemContribute::CLI::Issues do
 
     after { FileUtils.rm_rf(tmpdir) }
 
-    it "dedupes issues returned for multiple labels by issue number" do
-      shared_issue = issue(1234, "Shared issue")
-      allow(adapter).to receive(:issues).with(project, labels: ["good first issue"])
-                                        .and_return([shared_issue])
-      allow(adapter).to receive(:issues).with(project, labels: ["good-first-issue"])
-                                        .and_return([shared_issue, issue(5678, "Other issue")])
-      allow(adapter).to receive(:issues).with(project, labels: ["help wanted"])
-                                        .and_return([])
+    it "passes all preferred_labels to issues_matching_labels in a single call" do
+      allow(adapter).to receive(:issues_matching_labels)
+        .with(anything, labels: ["good first issue", "good-first-issue", "help wanted"])
+        .and_return("rubocop/rubocop" => [issue(1234, "Shared issue"), issue(5678, "Other issue")])
 
       expect(cli_with_config.run(["rubocop"])).to eq(0)
       expect(stdout.string).to include("#1234")
       expect(stdout.string).to include("#5678")
-      expect(stdout.string).to match(/2 open/)
+      expect(adapter).to have_received(:issues_matching_labels).once
     end
 
     it "uses custom preferred_labels from config instead of defaults" do
       config.set("preferred_labels", "help wanted")
-      allow(adapter).to receive(:issues).with(project, labels: ["help wanted"])
-                                        .and_return([issue(99, "Help wanted issue")])
+      allow(adapter).to receive(:issues_matching_labels)
+        .with(anything, labels: ["help wanted"])
+        .and_return("rubocop/rubocop" => [issue(99, "Help wanted issue")])
 
       expect(cli_with_config.run(["rubocop"])).to eq(0)
       expect(stdout.string).to include("#99")
-      expect(adapter).not_to have_received(:issues).with(project, labels: ["good first issue"])
+      expect(adapter).not_to have_received(:issues_matching_labels)
+        .with(anything, labels: array_including("good first issue"))
     end
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers
 
   describe "rate-limit footer" do
     it "appends the footer after `issues <gem>` when adapter recorded one" do
-      allow(adapter).to receive_messages(issues: [issue(1, "x")],
-                                         rate_limit: Struct.new(:limit, :remaining, :reset_at).new(
-                                           5000, 4587, Time.utc(2026, 4, 30, 14, 32, 0)
-                                         ))
+      allow(adapter).to receive_messages(
+        issues_matching_labels: { "rubocop/rubocop" => [issue(1, "x")] },
+        rate_limit: Struct.new(:limit, :remaining, :reset_at).new(
+          5000, 4587, Time.utc(2026, 4, 30, 14, 32, 0)
+        )
+      )
 
       expect(cli.run(["rubocop"])).to eq(0)
       expect(stdout.string).to include("GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC")
     end
 
     it "appends the footer after `issues all` when adapter recorded one" do
-      allow(adapter).to receive_messages(issues: [],
-                                         rate_limit: Struct.new(:limit, :remaining, :reset_at).new(
-                                           60, 12, Time.utc(2026, 4, 30, 9, 5, 0)
-                                         ))
+      allow(adapter).to receive_messages(
+        issues_matching_labels: {},
+        rate_limit: Struct.new(:limit, :remaining, :reset_at).new(
+          60, 12, Time.utc(2026, 4, 30, 9, 5, 0)
+        )
+      )
 
       expect(cli.run(["all"])).to eq(0)
       expect(stdout.string).to include("GitHub rate limit: 12 / 60 remaining · resets at 09:05 UTC")
     end
 
     it "prints nothing extra when the adapter has no rate-limit data" do
-      allow(adapter).to receive(:issues).and_return([])
-      # rate_limit defaults to nil via the spec's top-level before block.
+      allow(adapter).to receive(:issues_matching_labels).and_return({})
 
       expect(cli.run(["all"])).to eq(0)
       expect(stdout.string).not_to include("GitHub rate limit")

--- a/spec/gem_contribute/cli/scan_spec.rb
+++ b/spec/gem_contribute/cli/scan_spec.rb
@@ -11,24 +11,117 @@ RSpec.describe GemContribute::CLI::Scan do
   let(:fixtures) { File.expand_path("../../fixtures", __dir__) }
   let(:lockfile) { File.join(fixtures, "Gemfile.simple.lock") }
 
-  # Default: every adapter mock returns nil from rate_limit so the
-  # post-scan footer is a no-op. Tests that exercise the footer
-  # explicitly override this.
   before do
     allow(adapter).to receive(:rate_limit).and_return(nil)
-    # Default: no claimed issues. Tests that exercise the suffix override.
     allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index).and_return({})
+  end
+
+  def project(gem_name, host: "github.com", owner: "ruby", repo: nil)
+    GemContribute::Project.new(
+      gem_name: gem_name, host: host, owner: owner,
+      repo: repo || gem_name, metadata: {}
+    )
+  end
+
+  def unresolved_project(gem_name, reason: GemContribute::Resolver::REASON_NON_RUBYGEMS_SOURCE)
+    GemContribute::Project.new(
+      gem_name: gem_name, host: :unknown, owner: nil, repo: nil,
+      metadata: { reason: reason }
+    )
+  end
+
+  it "prints a host summary line and a ranked top-projects list" do
+    allow(resolver).to receive(:resolve) do |gem|
+      case gem.name
+      when "rake"            then project("rake", owner: "ruby", repo: "rake")
+      when "sidekiq"         then project("sidekiq", owner: "sidekiq", repo: "sidekiq")
+      when "connection_pool" then project("connection_pool", owner: "mperham", repo: "connection_pool")
+      when "logger"          then unresolved_project("logger", reason: :unknown_host)
+      when "rack"            then project("rack", owner: "rack", repo: "rack")
+      end
+    end
+    allow(adapter).to receive(:issues_matching_labels).and_return(
+      "sidekiq/sidekiq" => Array.new(5) { |i| { "number" => i + 1 } },
+      "ruby/rake" => [{ "number" => 10 }],
+      "rack/rack" => [{ "number" => 9 }, { "number" => 11 }]
+    )
+
+    expect(scan.run([lockfile])).to eq(0)
+
+    out = stdout.string
+    expect(out).to include("5 gems")
+    expect(out).to include("on github.com")
+    expect(out).to include("Top contributable projects")
+    expect(out).to match(%r{sidekiq\s+5\s+github\.com/sidekiq/sidekiq})
+    rack_line = out.lines.index { |l| l.include?("rack ") || l.include?("rack  ") }
+    rake_line = out.lines.index { |l| l.match?(/rake\s+1\s+/) }
+    expect(rack_line).to be < rake_line
+  end
+
+  it "prints a no-github message when no lockfile gems resolve to github.com" do
+    allow(resolver).to receive(:resolve).and_return(unresolved_project("rake"))
+    allow(adapter).to receive(:issues_matching_labels).and_return({})
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stdout.string).to include("No github.com projects")
+  end
+
+  it "auto-injects gem-contribute itself into the ranked list" do
+    allow(resolver).to receive(:resolve).and_return(unresolved_project("rake"))
+    allow(adapter).to receive(:issues_matching_labels).and_return(
+      "cdhagmann/gem-contribute" => [{ "number" => 1 }, { "number" => 2 }]
+    )
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stdout.string).to match(%r{gem-contribute\s+2\s+github\.com/cdhagmann/gem-contribute})
+  end
+
+  it "exits 1 with a clear stderr message when the lockfile is missing" do
+    expect(scan.run(["/nonexistent/Gemfile.lock"])).to eq(1)
+    expect(stderr.string).to include("no Gemfile.lock")
+  end
+
+  it "warns when the search fails but doesn't crash the scan" do
+    allow(resolver).to receive(:resolve).and_return(project("sidekiq", owner: "sidekiq", repo: "sidekiq"))
+    allow(adapter).to receive(:issues_matching_labels).and_raise(GemContribute::AdapterError, "boom")
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stderr.string).to include("issue search failed")
+    expect(stderr.string).to include("boom")
+  end
+
+  it "appends the GitHub rate-limit footer when adapter recorded one" do
+    allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
+    allow(adapter).to receive_messages(
+      issues_matching_labels: { "ruby/rake" => [{ "number" => 1 }] },
+      rate_limit: Struct.new(:limit, :remaining, :reset_at).new(
+        5000, 4587, Time.utc(2026, 4, 30, 14, 32, 0)
+      )
+    )
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stdout.string).to include("GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC")
+  end
+
+  it "omits the footer when the adapter has no rate-limit data (cache-only run)" do
+    allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
+    allow(adapter).to receive(:issues_matching_labels).and_return({ "ruby/rake" => [{ "number" => 1 }] })
+
+    expect(scan.run([lockfile])).to eq(0)
+    expect(stdout.string).not_to include("GitHub rate limit")
   end
 
   it "appends a `· N claimed` suffix when the project has claimed issues" do
     allow(resolver).to receive(:resolve) do |gem|
-      project(gem.name) if gem.name == "rubocop"
+      project(gem.name, owner: "ruby", repo: gem.name) if gem.name == "rubocop"
     end
-    allow(adapter).to receive(:issues).and_return([{ "number" => 1 }, { "number" => 2 }])
+    allow(adapter).to receive(:issues_matching_labels).and_return(
+      "ruby/rubocop" => [{ "number" => 1 }, { "number" => 2 }]
+    )
     allow(GemContribute::CLI::IssueAnnouncer).to receive(:fetch_claim_index)
       .and_return("ruby/rubocop" => [1])
 
-    rubocop_only = File.join(fixtures, "Gemfile.rubocop_only.lock")
+    rubocop_only = File.join(File.expand_path("../../fixtures", __dir__), "Gemfile.rubocop_only.lock")
     File.write(rubocop_only, <<~LOCKFILE)
       GEM
         remote: https://rubygems.org/
@@ -46,108 +139,6 @@ RSpec.describe GemContribute::CLI::Scan do
     File.delete(rubocop_only)
   end
 
-  def project(gem_name, host: "github.com", owner: "ruby", repo: nil)
-    GemContribute::Project.new(
-      gem_name: gem_name,
-      host: host,
-      owner: owner,
-      repo: repo || gem_name,
-      metadata: {}
-    )
-  end
-
-  def unresolved_project(gem_name, reason: GemContribute::Resolver::REASON_NON_RUBYGEMS_SOURCE)
-    GemContribute::Project.new(
-      gem_name: gem_name, host: :unknown, owner: nil, repo: nil,
-      metadata: { reason: reason }
-    )
-  end
-
-  it "prints a host summary line and a ranked top-projects list" do
-    allow(resolver).to receive(:resolve) do |gem|
-      case gem.name
-      when "rake" then project("rake", owner: "ruby", repo: "rake")
-      when "sidekiq" then project("sidekiq", owner: "sidekiq", repo: "sidekiq")
-      when "connection_pool" then project("connection_pool", owner: "mperham", repo: "connection_pool")
-      when "logger" then unresolved_project("logger", reason: :unknown_host)
-      when "rack" then project("rack", owner: "rack", repo: "rack")
-      end
-    end
-    allow(adapter).to receive(:issues) do |proj, _opts|
-      case proj.gem_name
-      when "sidekiq" then [{ "number" => 1 }, { "number" => 2 }, { "number" => 3 }, { "number" => 4 },
-                           { "number" => 5 }]
-      when "rake" then [{ "number" => 10 }]
-      when "rack" then [{ "number" => 9 }, { "number" => 11 }]
-      else []
-      end
-    end
-
-    expect(scan.run([lockfile])).to eq(0)
-
-    out = stdout.string
-    expect(out).to include("5 gems")
-    expect(out).to include("on github.com")
-    expect(out).to include("Top contributable projects")
-    expect(out).to match(%r{sidekiq\s+5\s+github\.com/sidekiq/sidekiq})
-    # rack (2) ranks above rake (1)
-    rack_line = out.lines.index { |l| l.include?("rack ") || l.include?("rack  ") }
-    rake_line = out.lines.index { |l| l.match?(/rake\s+1\s+/) }
-    expect(rack_line).to be < rake_line
-  end
-
-  it "prints a no-github message when no lockfile gems resolve to github.com" do
-    allow(resolver).to receive(:resolve).and_return(unresolved_project("rake"))
-    allow(adapter).to receive(:issues).and_return([])
-
-    expect(scan.run([lockfile])).to eq(0)
-    expect(stdout.string).to include("No github.com projects")
-  end
-
-  it "auto-injects gem-contribute itself into the ranked list" do
-    allow(resolver).to receive(:resolve).and_return(unresolved_project("rake"))
-    allow(adapter).to receive(:issues) do |proj, _opts|
-      proj.gem_name == "gem-contribute" ? [{ "number" => 1 }, { "number" => 2 }] : []
-    end
-
-    expect(scan.run([lockfile])).to eq(0)
-    expect(stdout.string).to match(%r{gem-contribute\s+2\s+github\.com/cdhagmann/gem-contribute})
-  end
-
-  it "exits 1 with a clear stderr message when the lockfile is missing" do
-    expect(scan.run(["/nonexistent/Gemfile.lock"])).to eq(1)
-    expect(stderr.string).to include("no Gemfile.lock")
-  end
-
-  it "warns on adapter errors but doesn't crash the whole scan" do
-    allow(resolver).to receive(:resolve).and_return(project("sidekiq", owner: "sidekiq", repo: "sidekiq"))
-    allow(adapter).to receive(:issues).and_raise(GemContribute::AdapterError, "boom")
-
-    expect(scan.run([lockfile])).to eq(0)
-    expect(stderr.string).to include("warning: sidekiq")
-    expect(stderr.string).to include("boom")
-  end
-
-  it "appends the GitHub rate-limit footer when adapter recorded one" do
-    allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
-    allow(adapter).to receive_messages(issues: [{ "number" => 1 }],
-                                       rate_limit: Struct.new(:limit, :remaining, :reset_at).new(
-                                         5000, 4587, Time.utc(2026, 4, 30, 14, 32, 0)
-                                       ))
-
-    expect(scan.run([lockfile])).to eq(0)
-    expect(stdout.string).to include("GitHub rate limit: 4,587 / 5,000 remaining · resets at 14:32 UTC")
-  end
-
-  it "omits the footer when the adapter has no rate-limit data (cache-only run)" do
-    allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
-    allow(adapter).to receive(:issues).and_return([{ "number" => 1 }])
-    # adapter.rate_limit defaults to nil via the top-level before block.
-
-    expect(scan.run([lockfile])).to eq(0)
-    expect(stdout.string).not_to include("GitHub rate limit")
-  end
-
   describe "preferred_labels" do
     let(:tmpdir) { Dir.mktmpdir("gem-contribute-scan-config-") }
     let(:config) { GemContribute::Config.new(path: File.join(tmpdir, "config.yml")) }
@@ -158,26 +149,28 @@ RSpec.describe GemContribute::CLI::Scan do
 
     after { FileUtils.rm_rf(tmpdir) }
 
-    it "dedupes issues by number across preferred labels so a shared issue is counted once" do
+    it "passes all preferred_labels to issues_matching_labels in a single call" do
       allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
-      shared = { "number" => 1 }
-      allow(adapter).to receive(:issues).with(anything, labels: ["good first issue"]).and_return([shared])
-      allow(adapter).to receive(:issues).with(anything, labels: ["good-first-issue"]).and_return([shared])
-      allow(adapter).to receive(:issues).with(anything, labels: ["help wanted"]).and_return([])
+      allow(adapter).to receive(:issues_matching_labels)
+        .with(anything, labels: ["good first issue", "good-first-issue", "help wanted"])
+        .and_return({ "ruby/rake" => [{ "number" => 1 }] })
 
       expect(scan_with_config.run([lockfile])).to eq(0)
       expect(stdout.string).to match(/rake\s+1\s+/)
+      expect(adapter).to have_received(:issues_matching_labels).once
     end
 
     it "uses custom preferred_labels from config" do
       config.set("preferred_labels", "help wanted")
       allow(resolver).to receive(:resolve).and_return(project("rake", owner: "ruby", repo: "rake"))
-      allow(adapter).to receive(:issues).with(anything, labels: ["help wanted"])
-                                        .and_return([{ "number" => 42 }])
+      allow(adapter).to receive(:issues_matching_labels)
+        .with(anything, labels: ["help wanted"])
+        .and_return({ "ruby/rake" => [{ "number" => 42 }] })
 
       expect(scan_with_config.run([lockfile])).to eq(0)
       expect(stdout.string).to match(/rake\s+1\s+/)
-      expect(adapter).not_to have_received(:issues).with(anything, labels: ["good first issue"])
+      expect(adapter).not_to have_received(:issues_matching_labels)
+        .with(anything, labels: array_including("good first issue"))
     end
   end
 end

--- a/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
+++ b/spec/gem_contribute/host_adapters/git_hub_adapter_spec.rb
@@ -237,6 +237,86 @@ RSpec.describe GemContribute::HostAdapters::GitHubAdapter do
     end
   end
 
+  describe "#issues_matching_labels" do
+    def project_for(owner, repo)
+      GemContribute::Project.new(gem_name: repo, host: "github.com",
+                                 owner: owner, repo: repo, metadata: {})
+    end
+
+    def search_stub(items)
+      stub_request(:get, %r{api\.github\.com/search/issues})
+        .to_return(status: 200,
+                   headers: { "Content-Type" => "application/json",
+                              "X-RateLimit-Limit" => "30",
+                              "X-RateLimit-Remaining" => "29",
+                              "X-RateLimit-Reset" => "1714510800" },
+                   body: JSON.dump("items" => items))
+    end
+
+    def search_item(number, owner, repo)
+      {
+        "number" => number,
+        "title" => "Issue #{number}",
+        "html_url" => "https://github.com/#{owner}/#{repo}/issues/#{number}",
+        "repository_url" => "https://api.github.com/repos/#{owner}/#{repo}"
+      }
+    end
+
+    it "returns a hash keyed by owner/repo with issues as values" do
+      search_stub([
+                    search_item(1, "sidekiq", "sidekiq"),
+                    search_item(2, "ruby", "rake")
+                  ])
+      rake = project_for("ruby", "rake")
+
+      result = adapter.issues_matching_labels([project, rake], labels: ["good first issue"])
+
+      expect(result["sidekiq/sidekiq"].map { |i| i["number"] }).to eq([1])
+      expect(result["ruby/rake"].map { |i| i["number"] }).to eq([2])
+    end
+
+    it "returns {} immediately when the projects list is empty" do
+      result = adapter.issues_matching_labels([], labels: ["good first issue"])
+      expect(result).to eq({})
+      expect(WebMock).not_to have_requested(:get, %r{api\.github\.com/search})
+    end
+
+    it "returns {} immediately when labels is empty" do
+      result = adapter.issues_matching_labels([project], labels: [])
+      expect(result).to eq({})
+      expect(WebMock).not_to have_requested(:get, %r{api\.github\.com/search})
+    end
+
+    it "batches repos #{described_class::SEARCH_BATCH_SIZE} at a time" do
+      search_stub([])
+
+      projects = (1..11).map { |i| project_for("owner", "gem#{i}") }
+      adapter.issues_matching_labels(projects, labels: ["good first issue"])
+
+      expect(WebMock).to have_requested(:get, %r{api\.github\.com/search/issues}).twice
+    end
+
+    it "caches by query so repeat calls with the same projects and labels hit the API once" do
+      search_stub([search_item(7, "sidekiq", "sidekiq")])
+
+      adapter.issues_matching_labels([project], labels: ["good first issue"])
+      adapter.issues_matching_labels([project], labels: ["good first issue"])
+
+      expect(WebMock).to have_requested(:get, %r{api\.github\.com/search/issues}).once
+    end
+
+    it "sends OR-combined label terms and repo: qualifiers in the search query" do
+      search_stub([])
+
+      adapter.issues_matching_labels([project], labels: ["good first issue", "help wanted"])
+
+      expect(WebMock).to have_requested(:get, %r{api\.github\.com/search/issues})
+        .with(query: hash_including(
+          "q" => 'is:issue state:open (label:"good first issue" OR label:"help wanted") repo:sidekiq/sidekiq'
+        ))
+    end
+  end
+
   describe "#pull_request_url" do
     let(:upstream) do
       GemContribute::Project.new(


### PR DESCRIPTION
## Summary

- Replaces per-project per-label Issues API calls with a single batched GitHub Search API request per 10 repos
- Search query uses OR semantics: `is:issue state:open (label:"A" OR label:"B") repo:o/r1 repo:o/r2 …`
- Reduces N×labels network round trips to `ceil(N/10)` calls for both `scan` and `issues all`
- Results are cached by the full query string; same-lockfile repeat scans still hit cache

## Linked issue / ADR

Closes #52 (reduces API call count to avoid rate limiting).

## Working agreement

- [x] No new architectural boundaries crossed — adapter change stays inside `GitHubAdapter`
- [x] Specs updated for all three affected files (`github_adapter_spec`, `scan_spec`, `issues_spec`)
- [x] `bin/rubocop` clean
- [x] `bundle exec rspec` — 246 examples, 0 failures

## Test plan

- [x] `#issues_matching_labels` unit tests: hash return format, empty-inputs short-circuit, batching (11 repos → 2 requests), caching (same call → 1 request), OR query structure
- [x] `scan_spec` fully rewritten to mock `issues_matching_labels` returning a hash
- [x] `issues_spec` fully rewritten; batch-level failure test replaces per-gem failure test

🤖 Generated with [Claude Code](https://claude.com/claude-code)