### PR TITLE
feat(cli): add `gem-contribute open <gem>`

### DIFF
--- a/lib/gem_contribute/cli.rb
+++ b/lib/gem_contribute/cli.rb
@@ -23,6 +23,8 @@ module GemContribute
                                  GitHub project (e.g. `rubyevents/rubyevents`).
                                  Lands on the default branch.
                                  Flags: -e (editor), -a (AI tool).
+        open <gem>               Open the gem's GitHub repo in your default browser.
+                                 The URL is also printed on stdout as a fallback.
         fix <gem>/<issue#>       Fork the gem's repo, clone the fork, branch from main.
                                  Flags: -e (editor), -a (AI tool), --no-comment.
         submit                   Push the current branch and open a pre-filled
@@ -63,6 +65,7 @@ module GemContribute
       "config" => ->(o, e) { Config.new(stdout: o, stderr: e) },
       "auth" => ->(o, e) { Auth.new(stdout: o, stderr: e) },
       "fork" => ->(o, e) { Fork.new(stdout: o, stderr: e, clone_root: GemContribute::Config.new.clone_root) },
+      "open" => ->(o, e) { Open.new(stdout: o, stderr: e) },
       "fix" => lambda { |o, e|
         config = GemContribute::Config.new
         Fix.new(stdout: o, stderr: e, clone_root: config.clone_root, config: config)

--- a/lib/gem_contribute/cli/open.rb
+++ b/lib/gem_contribute/cli/open.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module GemContribute
+  module CLI
+    # `gem-contribute open <gem>` — print the gem's GitHub URL and try to open
+    # it in the default browser.
+    #
+    # Resolves `<gem>` the same way `issues` and `fix` do (RubyGems → Project,
+    # with the `gem-contribute` self short-circuit). The browser opener is the
+    # same platform-aware helper used by `auth login` and `submit`. As in those
+    # verbs, the opener is injected at construction so specs never shell out.
+    class Open
+      include PlatformTools
+      include Workflow
+
+      USAGE = "Usage: gem-contribute open <gem>"
+
+      def initialize(stdout: $stdout, stderr: $stderr, output: nil,
+                     resolver: Resolver.new,
+                     browser_opener: nil)
+        @output = output || Output::Standard.new(out: stdout, err: stderr)
+        @resolver = resolver
+        @browser_opener = browser_opener || method(:default_browser_opener)
+      end
+
+      def run(argv)
+        target = argv.shift
+        if target.nil?
+          @output.error(USAGE)
+          return 2
+        end
+
+        project = resolve_target(target, verb: "open")
+        return 1 if project.nil?
+
+        url = "https://github.com/#{project.owner}/#{project.repo}"
+        opened = @browser_opener.call(url)
+        @output.info(opened ? "Opened browser to:" : "Open this URL in your browser:")
+        @output.info("  #{url}")
+        0
+      end
+    end
+  end
+end

--- a/spec/gem_contribute/cli/open_spec.rb
+++ b/spec/gem_contribute/cli/open_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe GemContribute::CLI::Open do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:resolver) { instance_double(GemContribute::Resolver) }
+  let(:opened_urls) { [] }
+  let(:browser_opener) { ->(url) { opened_urls << url; true } }
+  let(:cli) do
+    described_class.new(stdout: stdout, stderr: stderr,
+                        resolver: resolver, browser_opener: browser_opener)
+  end
+
+  let(:project) do
+    GemContribute::Project.new(
+      gem_name: "rubocop", host: "github.com",
+      owner: "rubocop", repo: "rubocop", metadata: {}
+    )
+  end
+
+  it "exits 2 with a usage message when no gem name is given" do
+    expect(cli.run([])).to eq(2)
+    expect(stderr.string).to include("Usage: gem-contribute open <gem>")
+  end
+
+  it "opens the resolved repo URL in the browser and prints it" do
+    allow(resolver).to receive(:resolve).and_return(project)
+
+    expect(cli.run(["rubocop"])).to eq(0)
+    expect(opened_urls).to eq(["https://github.com/rubocop/rubocop"])
+    out = stdout.string
+    expect(out).to include("Opened browser to:")
+    expect(out).to include("https://github.com/rubocop/rubocop")
+  end
+
+  it "still prints the URL when the browser opener returns false" do
+    allow(resolver).to receive(:resolve).and_return(project)
+    failing_opener = ->(_url) { false }
+    cli = described_class.new(stdout: stdout, stderr: stderr,
+                              resolver: resolver, browser_opener: failing_opener)
+
+    expect(cli.run(["rubocop"])).to eq(0)
+    out = stdout.string
+    expect(out).to include("Open this URL in your browser:")
+    expect(out).to include("https://github.com/rubocop/rubocop")
+  end
+
+  it "exits 1 with a clear message when the gem resolves to a non-github.com host" do
+    other = GemContribute::Project.new(
+      gem_name: "internal", host: :unknown, owner: nil, repo: nil, metadata: {}
+    )
+    allow(resolver).to receive(:resolve).and_return(other)
+
+    expect(cli.run(["internal"])).to eq(1)
+    expect(stderr.string).to include("only github.com is supported")
+    expect(opened_urls).to be_empty
+  end
+
+  it "self-resolves `gem-contribute` without hitting the resolver" do
+    expect(resolver).not_to receive(:resolve)
+
+    expect(cli.run(["gem-contribute"])).to eq(0)
+    expect(opened_urls).to eq([
+                                "https://github.com/#{GemContribute::SELF_PROJECT.owner}/" \
+                                "#{GemContribute::SELF_PROJECT.repo}"
+                              ])
+  end
+end

--- a/spec/gem_contribute/cli/open_spec.rb
+++ b/spec/gem_contribute/cli/open_spec.rb
@@ -7,7 +7,12 @@ RSpec.describe GemContribute::CLI::Open do
   let(:stderr) { StringIO.new }
   let(:resolver) { instance_double(GemContribute::Resolver) }
   let(:opened_urls) { [] }
-  let(:browser_opener) { ->(url) { opened_urls << url; true } }
+  let(:browser_opener) do
+    lambda do |url|
+      opened_urls << url
+      true
+    end
+  end
   let(:cli) do
     described_class.new(stdout: stdout, stderr: stderr,
                         resolver: resolver, browser_opener: browser_opener)
@@ -59,9 +64,10 @@ RSpec.describe GemContribute::CLI::Open do
   end
 
   it "self-resolves `gem-contribute` without hitting the resolver" do
-    expect(resolver).not_to receive(:resolve)
+    allow(resolver).to receive(:resolve)
 
     expect(cli.run(["gem-contribute"])).to eq(0)
+    expect(resolver).not_to have_received(:resolve)
     expect(opened_urls).to eq([
                                 "https://github.com/#{GemContribute::SELF_PROJECT.owner}/" \
                                 "#{GemContribute::SELF_PROJECT.repo}"


### PR DESCRIPTION
## Summary

Adds `gem-contribute open <gem>`, a small CLI verb that resolves a gem
the same way `issues` and `fix` do and opens the resulting GitHub repo
URL in the default browser. The URL is always printed on stdout so the
command degrades cleanly when the platform opener fails or the user is
in a non-interactive shell.

The browser opener is injected at construction (matching `auth login`
and `submit`), so specs never shell out.

## Linked issue / ADR

Closes #3.

No ADR — this is a new CLI verb that fits inside the existing v1 CLI
shape (ADR-0015) and reuses the patterns already chosen for resolving
targets and opening URLs. ADR-0007 keeps `open` from drifting toward a
"summarize the project" verb; the only thing this command does is open
the repo URL.

## Working agreement

- [x] Single concern — one new verb, plus the dispatcher + USAGE entry
      that make it reachable.
- [ ] `bin/rubocop` and `bin/rspec` not run locally (no Ruby 3.2+
      installed on this machine; the project's CI runs both via
      Docker). `ruby -c` clean on all three new/changed files.
- [x] New behavior has tests covering the happy path, missing-arg,
      browser-opener fallback, non-github.com host, and the
      `gem-contribute` self-resolve.
- [x] No async work — `open` is a synchronous shell-out happening once,
      via the shared `default_browser_opener` already used elsewhere.

## Test plan

`spec/gem_contribute/cli/open_spec.rb` covers the five acceptance
criteria from the issue:

- `open` with no args exits 2 and prints the usage line on stderr
- `open <gem>` resolves through the injected resolver, opens
  `https://github.com/<owner>/<repo>`, and prints `Opened browser to:`
  followed by the URL
- when the injected `browser_opener` returns false, the verb still
  prints the URL on its own line, prefixed with `Open this URL in your
  browser:` (the fallback wording matches `submit`)
- a non-github.com host produces the same `only github.com is
  supported at v0.1` message as `fix` and `fork` and exits 1
- `gem-contribute` is self-resolved through `SELF_PROJECT` without
  hitting the resolver

`ruby -c` on the three new/changed files is clean. I couldn't run
`bin/rspec` or `bin/rubocop` locally — system Ruby is 2.6 and the
Gemfile.lock requires Bundler 4 / Ruby 3.2+ — but the implementation
follows the same dependency-injection patterns used by `auth.rb`,
`submit.rb`, and `issues.rb`, so the file should pass CI without
adjustment. Happy to amend if anything trips.

## Notes for reviewer

- The verb deliberately doesn't take any flags. The issue mentioned a
  workshop-friendly tour-of-the-codebase scope and the existing
  `default_browser_opener` is already platform-aware, so there's
  nothing to thread through.
- I followed `submit.rb`'s pattern of always printing the URL on a
  separate line (so the "Opening..." message is short and the URL is
  greppable in shell history). The issue's example had the URL inline
  in the "Opening..." line; I'm easy on either, happy to adjust if you
  prefer the inline form.
- `open` is wired into the dispatcher between `fork` and `fix` because
  it pairs naturally with those verbs in the workflow (fork the repo,
  open the repo, fix the issue) — the alphabetical order would have
  put it after `init`. Easy to move if you'd rather keep the table
  alphabetical.
