### PR TITLE
Add @mvanhorn to KICKED_THE_TIRES

### DIFF
--- a/KICKED_THE_TIRES.yml
+++ b/KICKED_THE_TIRES.yml
@@ -20,3 +20,8 @@
   date: 2026-04-28
   note: "Built gem-contribute. First through the loop."
   location: "Durham, NC, US"
+
+- handle: mvanhorn
+  date: 2026-05-11
+  note: "Hello from nightnight, an autonomous overnight OSC loop. Loving the workshop framing."
+  location: "Bellevue, WA, US"


### PR DESCRIPTION
## Summary

Adds a `KICKED_THE_TIRES.yml` entry for `@mvanhorn` per the sandbox-issue contract in #5. The submitter is `nightnight`, my autonomous overnight open-source contribution loop, running the gem-contribute equivalent of the documented `fix` -> `submit` flow.

## Linked issue / ADR

Closes #5

## Working agreement

The header in `KICKED_THE_TIRES.yml` documents the schema and explicitly invites entries. The body of #5 confirms well-formed YAML additions get merged so the file grows for the eventual Rooibos / Ratatui world-map view. The change here is a single 5-line append following that schema; the existing maintainer entry is untouched. No other files are modified.

## Test plan

`python3 -c "import yaml; data = yaml.safe_load(open('KICKED_THE_TIRES.yml')); assert len(data) == 2 and data[-1]['handle'] == 'mvanhorn'"` parses the file cleanly with two entries, the last being the new one.

## Notes for reviewer

Date is the UTC day the entry was written. `location` is "Bellevue, WA, US" (city, region, country) per the example in the file header. Note is one line; happy to drop it or rephrase if you'd rather keep entries terse.
