### PR TITLE
ci(auto-merge): grant issues:write and merge before commenting

### DIFF
--- a/.github/workflows/auto-merge-kicked-tires.yml
+++ b/.github/workflows/auto-merge-kicked-tires.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   validate-and-merge:
@@ -72,9 +73,9 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
-          gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "🎉 Thanks @${PR_AUTHOR} for kicking the tires! Auto-merging."
           gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "🎉 Thanks @${PR_AUTHOR} for kicking the tires! Auto-merging." || true
 
       - name: Comment on validation failure
         if: failure() && steps.check.outputs.auto_merge == 'true'


### PR DESCRIPTION
## Summary

Auto-merge of [#68](https://github.com/cdhagmann/gem-contribute/pull/68) (a fork PR) failed because the workflow's `gh pr comment` was denied (`GraphQL: Resource not accessible by integration (addComment)`). The workflow declared `pull-requests: write` but not `issues: write`, and `gh pr comment` posts via the GraphQL `addComment` mutation, which is enforced under the `issues` scope. `set -euo pipefail` then aborted the step before `gh pr merge` ran. This grants `issues: write`, reorders the step so merge runs before the celebratory comment, and makes that comment best-effort.

## Linked issue / ADR

No issue — surfaced by the [failed run](https://github.com/cdhagmann/gem-contribute/actions/runs/25658375792/job/75312334758) on PR [#68](https://github.com/cdhagmann/gem-contribute/pull/68). No ADR: this is workflow plumbing, not an architectural change.

## Working agreement

- [x] Single concern (workflow permission + ordering fix; no unrelated changes)
- [x] `bin/rubocop` and `bin/rspec` pass locally — N/A, workflow-only change with no Ruby diff
- [x] New behavior has a test; bug fix has a regression test — N/A, GitHub Actions workflows aren't unit-tested in this repo; verification is end-to-end (see Test plan)
- [x] Async work goes through Rooibos Commands — N/A, no Ruby code changed

## Test plan

End-to-end: once this lands on `main`, the `pull_request_target` workflow re-runs against the **base-branch** version on the next `synchronize` event, so the fix applies retroactively to PR [#68](https://github.com/cdhagmann/gem-contribute/pull/68). Plan:

1. Merge this PR.
2. Close-and-reopen [#68](https://github.com/cdhagmann/gem-contribute/pull/68) (or push a no-op commit to Matt's branch) to retrigger `validate-and-merge`.
3. Expected: lint passes (`✓ 2 entries, all valid` was already green), then `gh pr merge --squash --delete-branch` succeeds, then the "🎉 Thanks…" comment posts.
4. If the comment regresses again, `|| true` keeps the merge effective — check the run log for permission drift.

## Notes for reviewer

- Considered flipping the repo-wide `default_workflow_permissions` from `read` to `write`, but per-workflow declarations are the more conservative path and match the rest of the repo.
- The same `issues: write` permission also benefits the `if: failure()` "validation failure" comment step in this workflow, which would have hit the same denial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)