### PR TITLE
ci: auto-reopen issue #5 if it's ever closed

### DIFF
--- a/.github/workflows/keep-issue-5-open.yml
+++ b/.github/workflows/keep-issue-5-open.yml
@@ -1,0 +1,32 @@
+name: Keep issue #5 open
+
+# Issue #5 ("Call `gem-contribute fix` and `submit` against me") is the
+# perpetual contribution target — people run the tool against this repo
+# and the tool opens fix-PRs that reference #5. If someone closes it
+# (accidentally, or because a bot ages it out), this workflow reopens it
+# and explains why.
+#
+# Security note: pull_request_target isn't relevant here — this fires on
+# `issues: closed` from the base branch. The GITHUB_TOKEN needs
+# `issues: write` to reopen and comment.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  reopen:
+    if: github.event.issue.number == 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reopen and explain
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh issue reopen 5 --repo "$REPO" \
+            --comment "This issue is intentionally evergreen — it's the contribution target for \`gem-contribute fix\` and \`submit\` against this repo. Reopening automatically. See [CLAUDE.md](https://github.com/$REPO/blob/main/CLAUDE.md) and the issue description for context."


### PR DESCRIPTION
## Summary

Adds a tiny GitHub Actions workflow that listens for `issues: closed` and reopens [#5](https://github.com/cdhagmann/gem-contribute/issues/5) (with a short explanation comment) whenever it gets closed. #5 is the perpetual "run `gem-contribute fix`/`submit` against me" contribution target — accidentally closing it breaks the documented onboarding flow. This is the third leg of the protection stool alongside pinning and locking the issue, both of which were applied manually.

## Linked issue / ADR

Touches [#5](https://github.com/cdhagmann/gem-contribute/issues/5) (the issue this protects). No ADR: this is repo-tooling plumbing, not architecture.

## Working agreement

- [x] Single concern (one workflow, one purpose: keep #5 open)
- [x] `bin/rubocop` and `bin/rspec` pass locally — N/A, workflow-only change with no Ruby diff
- [x] New behavior has a test; bug fix has a regression test — N/A, GitHub Actions workflows aren't unit-tested in this repo; verification is end-to-end (see Test plan)
- [x] Async work goes through Rooibos Commands — N/A, no Ruby code changed

## Test plan

End-to-end:

1. Merge this PR.
2. Close [#5](https://github.com/cdhagmann/gem-contribute/issues/5).
3. Expected within seconds: the workflow fires, the issue is reopened, and a comment is posted explaining why.
4. Confirm the `if: github.event.issue.number == 5` guard prevents the job from running for any other issue close (the job step will be skipped, no runner time spent).

## Notes for reviewer

- Considered making this generic ("protect any issue labeled `evergreen`") but YAGNI — there's exactly one such issue and the explicit `== 5` guard is easier to reason about. Happy to generalize if we add a second evergreen issue.
- The reopen `--comment` is best-effort via `set -e`: if commenting fails the workflow fails loudly rather than silently letting the issue stay closed. Reopen-then-comment ordering also means the issue is back open even if the comment call hits a transient error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)